### PR TITLE
Fix sector table trade mapping for option feeds

### DIFF
--- a/apps/web/src/app/pages/dashboard/components/sector-table/sector-table.component.html
+++ b/apps/web/src/app/pages/dashboard/components/sector-table/sector-table.component.html
@@ -18,10 +18,11 @@
         <th>Change</th>
         <th class="num">Qty</th>
         <th class="num">OI</th>
+        <th class="num">IV</th>
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let r of rows; trackBy: trackTx">
+      <tr *ngFor="let r of rows; trackBy: trackRow">
         <td>{{ r.ts | date:'HH:mm:ss' }}</td>
         <td><span class="side" [class.ce]="r.optionType==='CE'" [class.pe]="r.optionType==='PE'">{{ r.optionType }}</span></td>
         <td class="num">{{ r.strike }}</td>
@@ -36,6 +37,7 @@
         </td>
         <td class="num">{{ r.qty === null ? '—' : r.qty }}</td>
         <td class="num">{{ r.oi === null ? '—' : r.oi }}</td>
+        <td class="num">{{ r.iv == null ? '—' : (r.iv | number:'1.2-2') }}</td>
       </tr>
     </tbody>
   </table>

--- a/apps/web/src/app/pages/dashboard/components/sector-table/sector-table.component.ts
+++ b/apps/web/src/app/pages/dashboard/components/sector-table/sector-table.component.ts
@@ -2,8 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { interval, Subscription } from 'rxjs';
 import { finalize } from 'rxjs/operators';
-import { MarketDataService } from '../../../../services/market-data.service';
-import { TradeRow } from '../../../../models/trade-row';
+import { MarketDataService, SectorTradeRow } from '../../../../services/market-data.service';
 
 @Component({
   selector: 'app-sector-table',
@@ -15,7 +14,7 @@ import { TradeRow } from '../../../../models/trade-row';
 export class SectorTableComponent implements OnInit, OnDestroy {
   selectedSide: 'both' | 'CE' | 'PE' = 'both';
   limit = 50;
-  rows: TradeRow[] = [];
+  rows: SectorTradeRow[] = [];
   loading = true;
   lastLoadedAt?: string;
   private timerSub?: Subscription;
@@ -36,11 +35,11 @@ export class SectorTableComponent implements OnInit, OnDestroy {
       this.loading = true;
     }
     this.marketData
-      .getSectorTrades(this.limit, this.selectedSide)
+      .getSectorTrades(this.selectedSide, this.limit)
       .pipe(finalize(() => (this.loading = false)))
       .subscribe({
-        next: rows => {
-          this.rows = rows ?? [];
+        next: res => {
+          this.rows = res.rows ?? [];
           this.lastLoadedAt = new Date().toISOString();
         },
         error: () => {
@@ -57,5 +56,5 @@ export class SectorTableComponent implements OnInit, OnDestroy {
     }
   }
 
-  trackTx = (_: number, r: TradeRow) => r.txId;
+  trackRow = (_: number, r: SectorTradeRow) => r.ts + r.optionType + r.strike;
 }


### PR DESCRIPTION
## Summary
- fix SectorTableComponent to call getSectorTrades with correct side/limit ordering
- use SectorTradeRow type and add IV column in sector table

## Testing
- `npm test` *(fails: error TS18003: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b2133583e0832fbf33e9fae457e5e2