### PR TITLE
Handle offline CE/PE by ignoring stale live ticks

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -942,6 +942,8 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
     public List<OptTick> recentOptionTicks(String symbol) {
         ConcurrentLinkedDeque<OptTick> dq = optionBuffers.get(symbol);
         if (dq == null) return List.of();
+        Instant cutoff = Instant.now().minusSeconds(60);
+        dq.removeIf(t -> t.ts().isBefore(cutoff));
         return new ArrayList<>(dq);
     }
 


### PR DESCRIPTION
## Summary
- Drop option ticks older than 60s when serving recent data

## Testing
- `cd apps/api && ./mvnw -q test` *(fails: Could not resolve spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68b2170c5474832f9a66cd84982c99cd