### PR TITLE
Fetch Upstox balance for trade liquidity

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -38,7 +38,8 @@ public class CorsConfig {
                 "/md/sector-trades",
                 "/ops/live-status",
                 "/ops/influx-sanity",
-                "/ops/market-clock"
+                "/ops/market-clock",
+                "/ops/upstox-balance"
         );
         paths.forEach(p -> source.registerCorsConfiguration(p, config));
 

--- a/apps/api/src/main/java/com/trader/backend/controller/OpsController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/OpsController.java
@@ -3,21 +3,25 @@ package com.trader.backend.controller;
 import com.trader.backend.service.MarketHours;
 import com.trader.backend.service.LiveFeedService;
 import com.trader.backend.service.InfluxTickService;
+import com.trader.backend.service.UpstoxAuthService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.*;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import reactor.core.publisher.Mono;
 
 @RestController
 public class OpsController {
     private final LiveFeedService liveFeedService;
     private final InfluxTickService influxTickService;
+    private final UpstoxAuthService upstoxAuthService;
 
-    public OpsController(LiveFeedService liveFeedService, InfluxTickService influxTickService) {
+    public OpsController(LiveFeedService liveFeedService, InfluxTickService influxTickService, UpstoxAuthService upstoxAuthService) {
         this.liveFeedService = liveFeedService;
         this.influxTickService = influxTickService;
+        this.upstoxAuthService = upstoxAuthService;
     }
 
     @GetMapping("/ops/market-clock")
@@ -70,5 +74,11 @@ public class OpsController {
         m.put("futLastTs", s.futLastTs() != null ? s.futLastTs().toString() : null);
         m.put("optLastTs", s.optLastTs() != null ? s.optLastTs().toString() : null);
         return m;
+    }
+
+    @GetMapping("/ops/upstox-balance")
+    public Mono<Map<String, Object>> upstoxBalance() {
+        return upstoxAuthService.fetchBalance()
+                .map(bal -> Map.of("balance", bal));
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -291,6 +291,23 @@ public class UpstoxAuthService {
                 });
     }
 
+    /** Fetch the user's available cash balance from Upstox. */
+    public Mono<Double> fetchBalance() {
+        String token = accessToken.get();
+        if (token == null) {
+            log.warn("Access-token not ready. Hit /auth/exchange first.");
+            return Mono.just(0.0);
+        }
+
+        return webClient.get()
+                .uri("/user/funds")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(j -> j.at("/data/equity/available_margin").asDouble(0.0));
+    }
+
     /** For webhook based auth flows (unused but kept for completeness). */
     public Mono<Void> handleWebhook(String rawJson) {
         String code;

--- a/apps/web/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/web/src/app/pages/dashboard/dashboard.component.ts
@@ -11,6 +11,7 @@ import { SectorTradesComponent } from './sector-trades.component';
 import { AuthService } from '../../services/auth.service';
 import { formatCountdown } from '../../utils/time';
 import { MarketDataService } from '../../services/market-data.service';
+import { AccountService } from '../../services/account.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -32,7 +33,7 @@ import { Subscription } from 'rxjs';
 })
 export class DashboardComponent implements OnInit, OnDestroy {
   metrics = [
-    { title: 'Total Liquidity', value: '₹ 2,803,805.50' },
+    { title: 'Total Liquidity', value: '₹ 0.00' },
     { title: 'Daily Volume', value: '₹ 2,372,139.74' },
     { title: "Open Interest ('000)", value: '120.6' },
     { title: "Lots Traded ('000)", value: '271.35' }
@@ -52,7 +53,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   private tickSub?: Subscription;
 
-  constructor(private auth: AuthService, private marketData: MarketDataService) {}
+  constructor(private auth: AuthService, private marketData: MarketDataService, private account: AccountService) {}
 
   ngOnInit() {
     this.checkStatus();
@@ -96,6 +97,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
         this.connected = s.connected;
         this.expiresAt = s.expiresAt;
         this.remaining = s.remainingSeconds;
+        if (this.connected) {
+          this.account.getBalance().subscribe(b => {
+            this.metrics[0].value = '₹ ' + b.toFixed(2);
+          });
+        }
       }
     });
   }

--- a/apps/web/src/app/services/account.service.ts
+++ b/apps/web/src/app/services/account.service.ts
@@ -1,0 +1,16 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { map } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class AccountService {
+  private http = inject(HttpClient);
+  private apiBase = environment.apiBase;
+
+  getBalance() {
+    return this.http
+      .get<{ balance: number }>(`${this.apiBase}/ops/upstox-balance`)
+      .pipe(map(r => r.balance));
+  }
+}


### PR DESCRIPTION
## Summary
- expose `/ops/upstox-balance` endpoint to proxy Upstox funds
- fetch balance via new account service and display under Total Liquidity

## Testing
- `mvn -q test` *(fails: Network is unreachable for Maven dependencies)*
- `npm test --silent` *(fails: TS18003 No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b21c00a13c832fb978d8f91ce2dcd0