### PR TITLE
Display account balance on dashboard

### DIFF
--- a/apps/web/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/web/src/app/pages/dashboard/dashboard.component.ts
@@ -33,7 +33,7 @@ import { Subscription } from 'rxjs';
 })
 export class DashboardComponent implements OnInit, OnDestroy {
   metrics = [
-    { title: 'Total Liquidity', value: '₹ 0.00' },
+    { title: 'Balance', value: '₹ 0.00' },
     { title: 'Daily Volume', value: '₹ 2,372,139.74' },
     { title: "Open Interest ('000)", value: '120.6' },
     { title: "Lots Traded ('000)", value: '271.35' }
@@ -101,6 +101,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
           this.account.getBalance().subscribe(b => {
             this.metrics[0].value = '₹ ' + b.toFixed(2);
           });
+        } else {
+          this.metrics[0].value = '₹ 0.00';
         }
       }
     });


### PR DESCRIPTION
## Summary
- Show `Balance` instead of `Total Liquidity` on dashboard metrics
- Reset balance when disconnected and retrieve latest value when connected

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No inputs were found in config file '/workspace/Combinedfrontendbackend/apps/web/tsconfig.spec.json')*
- `./mvnw -q test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68b2eecc713c832f9c863b00c156475b