### PR TITLE
Display precise timestamps for sector trades

### DIFF
--- a/apps/web/src/app/pages/dashboard/components/sector-table/sector-table.component.html
+++ b/apps/web/src/app/pages/dashboard/components/sector-table/sector-table.component.html
@@ -23,7 +23,7 @@
     </thead>
     <tbody>
       <tr *ngFor="let r of rows; trackBy: trackRow">
-        <td>{{ r.ts | date:'HH:mm:ss' }}</td>
+        <td>{{ r.ts | date:'HH:mm:ss.SSS' }}</td>
         <td><span class="side" [class.ce]="r.optionType==='CE'" [class.pe]="r.optionType==='PE'">{{ r.optionType }}</span></td>
         <td class="num">{{ r.strike }}</td>
         <td class="num">{{ r.ltp | number:'1.2-2' }}</td>

--- a/apps/web/src/app/pages/dashboard/components/sector-table/sector-table.component.ts
+++ b/apps/web/src/app/pages/dashboard/components/sector-table/sector-table.component.ts
@@ -56,5 +56,5 @@ export class SectorTableComponent implements OnInit, OnDestroy {
     }
   }
 
-  trackRow = (_: number, r: SectorTradeRow) => r.ts + r.optionType + r.strike;
+  trackRow = (_: number, r: SectorTradeRow) => r.txId;
 }

--- a/apps/web/src/app/pages/dashboard/sector-trades.component.html
+++ b/apps/web/src/app/pages/dashboard/sector-trades.component.html
@@ -26,7 +26,7 @@
       </thead>
       <tbody>
         <tr *ngFor="let r of rows; trackBy: trackByTs">
-          <td>{{ r.ts | date:'HH:mm:ss' }}</td>
+          <td>{{ r.ts | date:'HH:mm:ss.SSS' }}</td>
           <td><span class="side-chip" [class.ce]="r.optionType==='CE'" [class.pe]="r.optionType==='PE'">{{ r.optionType }}</span></td>
           <td class="num">{{ r.strike }}</td>
           <td class="num">{{ r.ltp | number:'1.2-2' }}</td>

--- a/apps/web/src/app/pages/dashboard/sector-trades.component.ts
+++ b/apps/web/src/app/pages/dashboard/sector-trades.component.ts
@@ -60,6 +60,6 @@ export class SectorTradesComponent implements OnInit, OnDestroy {
     });
   }
 
-  trackByTs = (_: number, r: SectorTradeRow) => r.ts + r.optionType + r.strike;
+  trackByTs = (_: number, r: SectorTradeRow) => r.txId;
 }
 

--- a/apps/web/src/app/services/market-data.service.ts
+++ b/apps/web/src/app/services/market-data.service.ts
@@ -6,6 +6,7 @@ import { TradeRow } from '../models/trade-row';
 
 export interface SectorTradeRow {
   ts: string;
+  txId: string;
   optionType: 'CE' | 'PE';
   strike: number;
   ltp: number;


### PR DESCRIPTION
## Summary
- add unique txId to sector trade rows
- use txId for trackBy in sector trades and table components
- show millisecond precision for trade timestamps

## Testing
- `npm test` *(fails: No inputs were found in config file)*
- `mvn -q test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f1b3e1ec832f9748cf30bdf04947