### PR TITLE
Fix sector trades API base port

### DIFF
--- a/apps/web/src/environments/environment.ts
+++ b/apps/web/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiBase: 'http://localhost:8081'
+  // Use Spring Boot's default port for local API calls
+  apiBase: 'http://localhost:8080'
 };


### PR DESCRIPTION
## Summary
- point frontend API base to Spring Boot's default port 8080 so Sector CE/PE data loads

## Testing
- `npm test --silent` *(fails: error TS18003: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f3c39898832fa467e5607bfccaeb