### PR TITLE
Expose option IV in trade sector data

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/dto/TradeRow.java
+++ b/apps/api/src/main/java/com/trader/backend/dto/TradeRow.java
@@ -11,5 +11,6 @@ public record TradeRow(
         Double changePct,
         Integer qty,
         Integer oi,
+        Double iv,
         String txId
 ) {}

--- a/apps/web/src/app/models/trade-history.model.ts
+++ b/apps/web/src/app/models/trade-history.model.ts
@@ -9,5 +9,6 @@ export interface TradeRow {
   changePct: number;
   qty: number;
   oi: number;
+  iv: number | null;
   txId: string;
 }

--- a/apps/web/src/app/models/trade-row.ts
+++ b/apps/web/src/app/models/trade-row.ts
@@ -10,5 +10,6 @@ export interface TradeRow {
   changePct: number | null;
   qty: number | null;
   oi: number | null;
+  iv: number | null;
   txId: string;
 }


### PR DESCRIPTION
## Summary
- include implied volatility field in trade history records
- query and return `iv` from Influx option tick data
- expose `iv` in frontend trade row models

## Testing
- `./mvnw -q -ntp test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: No inputs were found in config file)*
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b2f67f3c24832fa3088e6396886762