### PR TITLE
Add Axis Bank historical data pipeline with Influx storage and UI chart

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/controller/AxisBankController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/AxisBankController.java
@@ -1,0 +1,36 @@
+package com.trader.backend.controller;
+
+import com.trader.backend.service.AxisBankHistoryService;
+import com.trader.backend.service.AxisBankHistoryService.Candle;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * Endpoints dedicated to Axis Bank historical data. These endpoints are
+ * additive and do not interfere with the existing trading workflow.
+ */
+@RestController
+@RequestMapping("/axisbank")
+@RequiredArgsConstructor
+public class AxisBankController {
+    private final AxisBankHistoryService service;
+
+    /** Trigger fetch from Upstox and store into Influx. */
+    @PostMapping("/fetch")
+    public Mono<List<Candle>> fetch() {
+        return service.fetchAndStore();
+    }
+
+    /** Return stored candles. */
+    @GetMapping(value = "/candles", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Candle> candles() {
+        return service.readCandles();
+    }
+}

--- a/apps/api/src/main/java/com/trader/backend/service/AxisBankHistoryService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/AxisBankHistoryService.java
@@ -1,0 +1,122 @@
+package com.trader.backend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.QueryApi;
+import com.influxdb.client.WriteApiBlocking;
+import com.influxdb.client.domain.WritePrecision;
+import com.influxdb.client.write.Point;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility service that can fetch historical candles for Axis Bank from the
+ * Upstox V3 API, persist them into InfluxDB and run a tiny analysis producing
+ * a report under src/main/resources/report.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AxisBankHistoryService {
+    private final MarketDataService marketDataService;
+    private final InfluxDBClient influxDBClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String AXIS_KEY = "NSE_EQ|INE238A01034";
+
+    @Value("${influx.org:}")
+    private String influxOrg;
+    @Value("${influx.bucket:}")
+    private String influxBucket;
+
+    /**
+     * Fetch candles from Upstox and store into Influx.
+     */
+    public Mono<List<Candle>> fetchAndStore() {
+        String today = LocalDate.now().toString();
+        return marketDataService
+                .candleV3(AXIS_KEY, "minute", 1, today, null)
+                .flatMap(json -> Mono.fromCallable(() -> parseAndStore(json)));
+    }
+
+    private List<Candle> parseAndStore(String json) throws IOException {
+        JsonNode node = objectMapper.readTree(json);
+        JsonNode data = node.path("data").path("candles");
+        List<Candle> candles = new ArrayList<>();
+        if (data.isArray()) {
+            WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
+            for (JsonNode c : data) {
+                String ts = c.get(0).asText();
+                double open = c.get(1).asDouble();
+                double high = c.get(2).asDouble();
+                double low = c.get(3).asDouble();
+                double close = c.get(4).asDouble();
+                long volume = c.get(5).asLong();
+                candles.add(new Candle(ts, open, high, low, close, volume));
+                Point p = Point.measurement("axisbank_candles")
+                        .time(Instant.parse(ts), WritePrecision.MS)
+                        .addField("o", open)
+                        .addField("h", high)
+                        .addField("l", low)
+                        .addField("c", close)
+                        .addField("v", volume);
+                writeApi.writePoint(influxBucket, influxOrg, p);
+            }
+        }
+        analyseAndWriteReport(candles);
+        return candles;
+    }
+
+    /**
+     * Query stored candles from Influx.
+     */
+    public List<Candle> readCandles() {
+        QueryApi queryApi = influxDBClient.getQueryApi();
+        String flux = String.format("from(bucket: \"%s\") |> range(start: -30d) |> " +
+                "filter(fn: (r) => r._measurement == \"axisbank_candles\") |> sort(columns:[\"_time\"])",
+                influxBucket);
+        List<Candle> result = new ArrayList<>();
+        queryApi.query(flux, influxOrg).forEach(table -> table.getRecords().forEach(rec -> {
+            Instant t = (Instant) rec.getValueByKey("_time");
+            Double o = rec.getValueByKey("o", Double.class);
+            Double h = rec.getValueByKey("h", Double.class);
+            Double l = rec.getValueByKey("l", Double.class);
+            Double c = rec.getValueByKey("c", Double.class);
+            Long v = rec.getValueByKey("v", Long.class);
+            if (o != null && h != null && l != null && c != null && v != null) {
+                result.add(new Candle(t.toString(), o, h, l, c, v));
+            }
+        }));
+        return result;
+    }
+
+    private void analyseAndWriteReport(List<Candle> candles) {
+        if (candles.isEmpty()) return;
+        double avgClose = candles.stream().mapToDouble(c -> c.close).average().orElse(0);
+        double maxHigh = candles.stream().mapToDouble(c -> c.high).max().orElse(0);
+        double minLow = candles.stream().mapToDouble(c -> c.low).min().orElse(0);
+        String report = String.format("candles=%d\navgClose=%.2f\nmaxHigh=%.2f\nminLow=%.2f\n",
+                candles.size(), avgClose, maxHigh, minLow);
+        try {
+            Path dir = Path.of("src/main/resources/report");
+            Files.createDirectories(dir);
+            Files.writeString(dir.resolve("axisbank-analysis.txt"), report);
+        } catch (IOException e) {
+            log.error("Failed writing report", e);
+        }
+    }
+
+    public record Candle(String time, double open, double high, double low, double close, long volume) {}
+}

--- a/apps/api/src/main/resources/report/axisbank-analysis.txt
+++ b/apps/api/src/main/resources/report/axisbank-analysis.txt
@@ -1,0 +1,1 @@
+Axis Bank report will be generated here.

--- a/apps/web/src/app/pages/dashboard/components/candle-panel/candle-panel.component.ts
+++ b/apps/web/src/app/pages/dashboard/components/candle-panel/candle-panel.component.ts
@@ -1,13 +1,6 @@
-import { AfterViewInit, Component, ElementRef, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, ViewChild, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
-interface Candle {
-  open: number;
-  high: number;
-  low: number;
-  close: number;
-  volume: number;
-}
+import { MarketDataService, Candle } from '../../../../services/market-data.service';
 
 @Component({
   selector: 'app-candle-panel',
@@ -19,27 +12,18 @@ interface Candle {
 export class CandlePanelComponent implements AfterViewInit {
   @ViewChild('canvas', { static: true }) canvas!: ElementRef<HTMLCanvasElement>;
   candles: Candle[] = [];
+  private md = inject(MarketDataService);
 
   ngAfterViewInit() {
-    this.generate();
-    this.draw();
+    this.md.getAxisBankCandles().subscribe(c => {
+      this.candles = c;
+      this.draw();
+    });
     window.addEventListener('resize', () => this.draw());
   }
 
-  generate() {
-    let price = 24835.25;
-    for (let i = 0; i < 60; i++) {
-      const open = price;
-      const close = open + (Math.random() - 0.5) * 20;
-      const high = Math.max(open, close) + Math.random() * 5;
-      const low = Math.min(open, close) - Math.random() * 5;
-      const volume = 100 + Math.random() * 200;
-      this.candles.push({ open, high, low, close, volume });
-      price = close;
-    }
-  }
-
   draw() {
+    if (!this.candles.length) return;
     const canvas = this.canvas.nativeElement;
     const ctx = canvas.getContext('2d')!;
     const dpr = window.devicePixelRatio || 1;

--- a/apps/web/src/app/services/market-data.service.ts
+++ b/apps/web/src/app/services/market-data.service.ts
@@ -84,6 +84,11 @@ export class MarketDataService {
     return this.http.get<Candle[]>(`${this.apiBase}/md/candles?instrumentKey=${encodeURIComponent(key)}&tf=1m&lookback=120`);
   }
 
+  /** candles specifically for Axis Bank stored in Influx */
+  getAxisBankCandles(): Observable<Candle[]> {
+    return this.http.get<Candle[]>(`${this.apiBase}/axisbank/candles`);
+  }
+
   getSectorTrades(side: 'both' | 'CE' | 'PE' = 'both', limit = 50): Observable<{ rows: SectorTradeRow[]; source?: 'live' | 'influx' }> {
     const params = new HttpParams().set('limit', limit).set('side', side);
     return this.http


### PR DESCRIPTION
## Summary
- Add AxisBankHistoryService to fetch Axis Bank candles from Upstox, store them in InfluxDB, and write a basic analysis report
- Expose new /axisbank endpoints for fetching and retrieving stored candles
- Display Axis Bank candles in dashboard by pulling data via MarketDataService

## Testing
- `npm test` *(fails: No inputs were found in config file)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b41f0bc378832fa384ad7ba21e48cf