### PR TITLE
fix: cast record field values

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/service/AxisBankHistoryService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/AxisBankHistoryService.java
@@ -90,16 +90,24 @@ public class AxisBankHistoryService {
         List<Candle> result = new ArrayList<>();
         queryApi.query(flux, influxOrg).forEach(table -> table.getRecords().forEach(rec -> {
             Instant t = (Instant) rec.getValueByKey("_time");
-            Double o = rec.getValueByKey("o", Double.class);
-            Double h = rec.getValueByKey("h", Double.class);
-            Double l = rec.getValueByKey("l", Double.class);
-            Double c = rec.getValueByKey("c", Double.class);
-            Long v = rec.getValueByKey("v", Long.class);
+            Double o = toDouble(rec.getValueByKey("o"));
+            Double h = toDouble(rec.getValueByKey("h"));
+            Double l = toDouble(rec.getValueByKey("l"));
+            Double c = toDouble(rec.getValueByKey("c"));
+            Long v = toLong(rec.getValueByKey("v"));
             if (o != null && h != null && l != null && c != null && v != null) {
                 result.add(new Candle(t.toString(), o, h, l, c, v));
             }
         }));
         return result;
+    }
+
+    private Double toDouble(Object value) {
+        return value instanceof Number ? ((Number) value).doubleValue() : null;
+    }
+
+    private Long toLong(Object value) {
+        return value instanceof Number ? ((Number) value).longValue() : null;
     }
 
     private void analyseAndWriteReport(List<Candle> candles) {


### PR DESCRIPTION
## Summary
- fix compile errors by casting FluxRecord values to numeric types

## Testing
- `./mvnw -q -e clean package -DskipFrontend=true -Dmaven.test.skip=true -Pci` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b49543175c832f9b0b7df0919a393f