### PR TITLE
fix: cast record field values

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/service/AxisBankHistoryService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/AxisBankHistoryService.java
@@ -90,16 +90,24 @@ public class AxisBankHistoryService {
         List<Candle> result = new ArrayList<>();
         queryApi.query(flux, influxOrg).forEach(table -> table.getRecords().forEach(rec -> {
             Instant t = (Instant) rec.getValueByKey("_time");
-            Double o = rec.getValueByKey("o", Double.class);
-            Double h = rec.getValueByKey("h", Double.class);
-            Double l = rec.getValueByKey("l", Double.class);
-            Double c = rec.getValueByKey("c", Double.class);
-            Long v = rec.getValueByKey("v", Long.class);
+            Double o = toDouble(rec.getValueByKey("o"));
+            Double h = toDouble(rec.getValueByKey("h"));
+            Double l = toDouble(rec.getValueByKey("l"));
+            Double c = toDouble(rec.getValueByKey("c"));
+            Long v = toLong(rec.getValueByKey("v"));
             if (o != null && h != null && l != null && c != null && v != null) {
                 result.add(new Candle(t.toString(), o, h, l, c, v));
             }
         }));
         return result;
+    }
+
+    private Double toDouble(Object value) {
+        return value instanceof Number ? ((Number) value).doubleValue() : null;
+    }
+
+    private Long toLong(Object value) {
+        return value instanceof Number ? ((Number) value).longValue() : null;
     }
 
     private void analyseAndWriteReport(List<Candle> candles) {

--- a/apps/web/src/app/pages/dashboard/components/candle-panel/candle-panel.component.ts
+++ b/apps/web/src/app/pages/dashboard/components/candle-panel/candle-panel.component.ts
@@ -15,10 +15,17 @@ export class CandlePanelComponent implements AfterViewInit {
   private md = inject(MarketDataService);
 
   ngAfterViewInit() {
-    this.md.getAxisBankCandles().subscribe(c => {
-      this.candles = c;
-      this.draw();
-    });
+    const load = () => {
+      this.md.getAxisBankCandles().subscribe(c => {
+        if (!c.length) {
+          this.md.fetchAxisBankCandles().subscribe(() => load());
+          return;
+        }
+        this.candles = c;
+        this.draw();
+      });
+    };
+    load();
     window.addEventListener('resize', () => this.draw());
   }
 

--- a/apps/web/src/app/services/market-data.service.ts
+++ b/apps/web/src/app/services/market-data.service.ts
@@ -89,6 +89,11 @@ export class MarketDataService {
     return this.http.get<Candle[]>(`${this.apiBase}/axisbank/candles`);
   }
 
+  /** trigger backend to fetch and persist Axis Bank candles */
+  fetchAxisBankCandles(): Observable<Candle[]> {
+    return this.http.post<Candle[]>(`${this.apiBase}/axisbank/fetch`, {});
+  }
+
   getSectorTrades(side: 'both' | 'CE' | 'PE' = 'both', limit = 50): Observable<{ rows: SectorTradeRow[]; source?: 'live' | 'influx' }> {
     const params = new HttpParams().set('limit', limit).set('side', side);
     return this.http


### PR DESCRIPTION
## Summary
- fix compile errors by casting FluxRecord values to numeric types
- load Axis Bank candle history on demand when dashboard loads

## Testing
- `./mvnw -q -e clean package -DskipFrontend=true -Dmaven.test.skip=true -Pci` *(failed: Non-resolvable parent POM: Network is unreachable)*
- `npm test` *(failed: error TS18003: No inputs were found in config file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b49543175c832f9b0b7df0919a393f