### PR TITLE
Fix buffering of sector trades and candles

### DIFF
--- a/apps/web/src/app/pages/dashboard/components/candle-panel/candle-panel.component.ts
+++ b/apps/web/src/app/pages/dashboard/components/candle-panel/candle-panel.component.ts
@@ -16,13 +16,25 @@ export class CandlePanelComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     const load = () => {
-      this.md.getAxisBankCandles().subscribe(c => {
-        if (!c.length) {
-          this.md.fetchAxisBankCandles().subscribe(() => load());
-          return;
+      this.md.getAxisBankCandles().subscribe({
+        next: c => {
+          if (!c.length) {
+            this.md.fetchAxisBankCandles().subscribe({
+              next: () => load(),
+              error: err => {
+                console.error('Failed to fetch candles', err);
+                setTimeout(load, 5000);
+              }
+            });
+            return;
+          }
+          this.candles = c;
+          this.draw();
+        },
+        error: err => {
+          console.error('Failed to load candles', err);
+          setTimeout(load, 5000);
         }
-        this.candles = c;
-        this.draw();
       });
     };
     load();

--- a/apps/web/src/app/pages/dashboard/components/sector-table/sector-table.component.ts
+++ b/apps/web/src/app/pages/dashboard/components/sector-table/sector-table.component.ts
@@ -42,8 +42,9 @@ export class SectorTableComponent implements OnInit, OnDestroy {
           this.rows = res.rows ?? [];
           this.lastLoadedAt = new Date().toISOString();
         },
-        error: () => {
-          this.rows = [];
+        error: err => {
+          console.error('Failed to load sector trades', err);
+          // keep existing rows on error so previously loaded data remains visible
         }
       });
   }

--- a/apps/web/src/app/services/market-data.service.ts
+++ b/apps/web/src/app/services/market-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NgZone, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { BehaviorSubject, Observable, Subject, catchError, of, map } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, catchError, of, map, timeout } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { TradeRow } from '../models/trade-row';
 
@@ -99,6 +99,7 @@ export class MarketDataService {
     return this.http
       .get<SectorTradeRow[]>(`${this.apiBase}/md/sector-trades`, { params, observe: 'response' })
       .pipe(
+        timeout(5000),
         map(res => {
           const header = res.headers.get('X-Source');
           const rows = (res.body || []).sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime());


### PR DESCRIPTION
## Summary
- retain previous CE/PE rows when loading fails
- retry Axis Bank candle loading on failure and log errors
- enforce a timeout when requesting sector trade data

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No inputs were found in config file 'tsconfig.spec.json')*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b49985d3c8832fa758990a5090559b