### PR TITLE
Add Axis Bank candle view with Influx 5-year data

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/service/AxisBankHistoryService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/AxisBankHistoryService.java
@@ -42,12 +42,17 @@ public class AxisBankHistoryService {
     private String influxBucket;
 
     /**
-     * Fetch candles from Upstox and store into Influx.
+     * Fetch 15-minute candles for the last 5 years from Upstox and store them
+     * into Influx. This will aggregate a much longer history than the
+     * previous one-day fetch.
      */
     public Mono<List<Candle>> fetchAndStore() {
-        String today = LocalDate.now().toString();
+        LocalDate today = LocalDate.now();
+        String to = today.toString();
+        // five years back from today
+        String from = today.minusYears(5).toString();
         return marketDataService
-                .candleV3(AXIS_KEY, "minute", 1, today, null)
+                .candleV3(AXIS_KEY, "minute", 15, to, from)
                 .flatMap(json -> Mono.fromCallable(() -> parseAndStore(json)));
     }
 
@@ -84,7 +89,7 @@ public class AxisBankHistoryService {
      */
     public List<Candle> readCandles() {
         QueryApi queryApi = influxDBClient.getQueryApi();
-        String flux = String.format("from(bucket: \"%s\") |> range(start: -30d) |> " +
+        String flux = String.format("from(bucket: \"%s\") |> range(start: -5y) |> " +
                 "filter(fn: (r) => r._measurement == \"axisbank_candles\") |> sort(columns:[\"_time\"])",
                 influxBucket);
         List<Candle> result = new ArrayList<>();

--- a/apps/web/src/app/app.routes.ts
+++ b/apps/web/src/app/app.routes.ts
@@ -2,10 +2,12 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { DashboardComponent } from './pages/dashboard/dashboard.component';
 import { LoginComponent } from './pages/login/login.component';
+import { AxisBankComponent } from './pages/axisbank/axisbank.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: '/login', pathMatch: 'full' },
   { path: 'dashboard', component: DashboardComponent },
+  { path: 'axisbank', component: AxisBankComponent },
   { path: 'login', component: LoginComponent }
   // (optional) add other routes
 ];

--- a/apps/web/src/app/pages/axisbank/axisbank.component.css
+++ b/apps/web/src/app/pages/axisbank/axisbank.component.css
@@ -1,0 +1,9 @@
+.axisbank-page {
+  margin-left: 4rem; /* leave space for side rail */
+  padding: 1rem;
+}
+
+.axisbank-page app-candle-panel {
+  display: block;
+  height: calc(100vh - 2rem);
+}

--- a/apps/web/src/app/pages/axisbank/axisbank.component.html
+++ b/apps/web/src/app/pages/axisbank/axisbank.component.html
@@ -1,0 +1,4 @@
+<app-side-rail></app-side-rail>
+<div class="axisbank-page">
+  <app-candle-panel></app-candle-panel>
+</div>

--- a/apps/web/src/app/pages/axisbank/axisbank.component.ts
+++ b/apps/web/src/app/pages/axisbank/axisbank.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SideRailComponent } from '../dashboard/components/side-rail/side-rail.component';
+import { CandlePanelComponent } from '../dashboard/components/candle-panel/candle-panel.component';
+
+@Component({
+  selector: 'app-axisbank',
+  standalone: true,
+  imports: [CommonModule, SideRailComponent, CandlePanelComponent],
+  templateUrl: './axisbank.component.html',
+  styleUrls: ['./axisbank.component.css']
+})
+export class AxisBankComponent {}

--- a/apps/web/src/app/pages/dashboard/components/side-rail/side-rail.component.html
+++ b/apps/web/src/app/pages/dashboard/components/side-rail/side-rail.component.html
@@ -1,6 +1,6 @@
 <nav class="rail">
-  <div class="icon btn">🏠</div>
-  <div class="icon btn">📈</div>
+  <div class="icon btn" routerLink="/dashboard">🏠</div>
+  <div class="icon btn" routerLink="/axisbank">📈</div>
   <div class="icon btn">👛</div>
   <div class="icon fab">+</div>
   <div class="icon btn">★</div>

--- a/apps/web/src/app/pages/dashboard/components/side-rail/side-rail.component.ts
+++ b/apps/web/src/app/pages/dashboard/components/side-rail/side-rail.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-side-rail',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   templateUrl: './side-rail.component.html',
   styleUrls: ['./side-rail.component.css']
 })


### PR DESCRIPTION
## Summary
- Fetch and store 15-minute Axis Bank candles for last 5 years in InfluxDB
- Add standalone Axis Bank candle page and route
- Enable chart icon to navigate to Axis Bank candles

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*
- `npm test --silent` *(fails: No inputs were found in config file 'tsconfig.spec.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b4a6e72ae0832f838cf8acd030caca