### PR TITLE
Add market status and OHLC endpoints with live data facade

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/controller/MarketController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/MarketController.java
@@ -1,0 +1,19 @@
+package com.trader.backend.controller;
+
+import com.trader.backend.service.MarketStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/market")
+@RequiredArgsConstructor
+public class MarketController {
+    private final MarketStatusService marketStatusService;
+
+    @GetMapping("/status")
+    public MarketStatusService.Status status() {
+        return marketStatusService.getStatus();
+    }
+}

--- a/apps/api/src/main/java/com/trader/backend/controller/OhlcController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/OhlcController.java
@@ -1,0 +1,24 @@
+package com.trader.backend.controller;
+
+import com.trader.backend.service.OhlcService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/ohlc")
+@RequiredArgsConstructor
+public class OhlcController {
+    private final OhlcService ohlcService;
+
+    @GetMapping("/cepe")
+    public List<OhlcService.Ohlc> cepe(@RequestParam String side,
+                                       @RequestParam(defaultValue="1s") String gran,
+                                       @RequestParam(defaultValue="900") int limit) {
+        return ohlcService.fetch(side, gran, limit);
+    }
+}

--- a/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -70,6 +70,7 @@ public class LiveFeedService {
     private final ObjectMapper om = new ObjectMapper();
     private final MongoTemplate mongoTemplate;
     private final QuantAnalysisService quantAnalysisService;
+    private final MarketStatusService marketStatusService;
     @Value("${app.mock:false}")
     private boolean mockMode;
 private final Sinks.Many<JsonNode> sink = Sinks.many().multicast().onBackpressureBuffer();
@@ -119,6 +120,7 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
     }
 
     public boolean isConnected() { return connected.get(); }
+    public boolean isWsConnected() { return connected.get(); }
     public Instant lastTickTs() { return lastTickTs.get(); }
     public long ticksLast60s() { return ticksLast60s.get(); }
     public boolean futSubscribed() { return futSubscribed.get(); }
@@ -736,6 +738,7 @@ public void streamNiftyFutAndTriggerCEPE() {
                         logLtp(instrumentKey, ltp, ts);
                         writeTickToInflux(instrumentKey, feed, ts);
                         lastTick.put(instrumentKey, new Tick(instrumentKey, ltp, Instant.ofEpochMilli(ts)));
+                        marketStatusService.onTick(ts);
                         bufferOptionTick(instrumentKey, feed, ts, ltp);
 
                         if (selectionComputed.compareAndSet(false, true)) {

--- a/apps/api/src/main/java/com/trader/backend/service/MarketStatusService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/MarketStatusService.java
@@ -1,26 +1,33 @@
 package com.trader.backend.service;
 
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
+import com.trader.backend.util.TradingHoursUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Derives a coarse market status (bullish, bearish, neutral) from
- * futures quantitative analysis results. This helps summarize the
- * broader market direction during mock runs.
+ * Tracks live market connection state and last tick timestamp.
  */
-@Component
-@Profile("mock")
+@Service
+@RequiredArgsConstructor
 public class MarketStatusService {
 
-    private static final double THRESHOLD = 0.0005; // 0.05%
+    private final LiveFeedService liveFeedService;
+    private final AtomicLong lastTickTs = new AtomicLong(0);
 
-    public MarketStatus determine(QuantAnalysisService.QuantAnalysisResult futuresResult) {
-        double m = futuresResult.momentum();
-        if (m > THRESHOLD) return MarketStatus.BULLISH;
-        if (m < -THRESHOLD) return MarketStatus.BEARISH;
-        return MarketStatus.NEUTRAL;
+    public void onTick(long ts) {
+        lastTickTs.set(ts);
     }
 
-    public enum MarketStatus { BULLISH, BEARISH, NEUTRAL }
-}
+    public Status getStatus() {
+        boolean wsConnected = liveFeedService.isWsConnected();
+        boolean open = TradingHoursUtil.isMarketOpen(Instant.now());
+        boolean online = open && wsConnected;
+        String reason = online ? "" : (open ? "ws-disconnected" : "market-closed");
+        return new Status(online, wsConnected, lastTickTs.get(), reason);
+    }
 
+    public record Status(boolean online, boolean wsConnected, long lastTickTs, String reason) {}
+}

--- a/apps/api/src/main/java/com/trader/backend/service/MockTickRunner.java
+++ b/apps/api/src/main/java/com/trader/backend/service/MockTickRunner.java
@@ -17,7 +17,7 @@ public class MockTickRunner implements CommandLineRunner {
 
     private final QuantAnalysisService quantAnalysisService;
     private final SyntheticTickGenerator syntheticTickGenerator;
-    private final MarketStatusService marketStatusService;
+    private final MomentumMarketStatusService marketStatusService;
 
     @Override
     public void run(String... args) throws Exception {

--- a/apps/api/src/main/java/com/trader/backend/service/MomentumMarketStatusService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/MomentumMarketStatusService.java
@@ -1,0 +1,26 @@
+package com.trader.backend.service;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Derives a coarse market status (bullish, bearish, neutral) from
+ * futures quantitative analysis results. This helps summarize the
+ * broader market direction during mock runs.
+ */
+@Component
+@Profile("mock")
+public class MomentumMarketStatusService {
+
+    private static final double THRESHOLD = 0.0005; // 0.05%
+
+    public MarketStatus determine(QuantAnalysisService.QuantAnalysisResult futuresResult) {
+        double m = futuresResult.momentum();
+        if (m > THRESHOLD) return MarketStatus.BULLISH;
+        if (m < -THRESHOLD) return MarketStatus.BEARISH;
+        return MarketStatus.NEUTRAL;
+    }
+
+    public enum MarketStatus { BULLISH, BEARISH, NEUTRAL }
+}
+

--- a/apps/api/src/main/java/com/trader/backend/service/OhlcService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/OhlcService.java
@@ -1,0 +1,98 @@
+package com.trader.backend.service;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.QueryApi;
+import com.influxdb.query.FluxRecord;
+import com.influxdb.query.FluxTable;
+import com.trader.backend.entity.NseInstrument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class OhlcService {
+    private final InfluxDBClient influxDBClient;
+    private final MongoTemplate mongoTemplate;
+
+    @Value("${influx.org:}")
+    private String influxOrg;
+    @Value("${influx.bucket:}")
+    private String influxBucket;
+
+    public List<Ohlc> fetch(String side, String gran, int limit) {
+        if (!"CE".equalsIgnoreCase(side) && !"PE".equalsIgnoreCase(side)) return List.of();
+        int lim = Math.max(1, Math.min(limit, 1000));
+        String start = "-" + lim + "s";
+        QueryApi queryApi = influxDBClient.getQueryApi();
+        Query q = new Query(Criteria.where("instrumentType").is(side));
+        List<NseInstrument> insts = mongoTemplate.find(q, NseInstrument.class, "filtered_nifty_premiums");
+        List<Ohlc> out = new ArrayList<>();
+        for (NseInstrument inst : insts) {
+            out.addAll(queryForInstrument(queryApi, inst.getInstrumentKey(), gran, start));
+        }
+        return out;
+    }
+
+    private List<Ohlc> queryForInstrument(QueryApi queryApi, String key, String gran, String start) {
+        Map<Instant, Builder> map = new HashMap<>();
+        String measurement = "nifty_option_ticks";
+        String tpl = """
+from(bucket: \"%s\")
+  |> range(start: %s)
+  |> filter(fn: (r) => r._measurement == \"%s\" and r.instrumentKey == \"%s\" and r._field == \"%s\")
+  |> aggregateWindow(every: %s, fn: %s, createEmpty: false)
+  |> keep(columns: [\"_time\",\"_value\"])
+  |> rename(columns: {_value: \"%s\"})
+""";
+        merge(queryApi.query(String.format(tpl, influxBucket, start, measurement, key, "ltp", gran, "last", "c"), influxOrg), "c", map);
+        merge(queryApi.query(String.format(tpl, influxBucket, start, measurement, key, "ltp", gran, "first", "o"), influxOrg), "o", map);
+        merge(queryApi.query(String.format(tpl, influxBucket, start, measurement, key, "ltp", gran, "max", "h"), influxOrg), "h", map);
+        merge(queryApi.query(String.format(tpl, influxBucket, start, measurement, key, "ltp", gran, "min", "l"), influxOrg), "l", map);
+        merge(queryApi.query(String.format(tpl, influxBucket, start, measurement, key, "volume", gran, "sum", "v"), influxOrg), "v", map);
+        List<Ohlc> list = new ArrayList<>();
+        for (var e : map.entrySet()) {
+            if (e.getValue().complete()) {
+                list.add(e.getValue().toOhlc(key, e.getKey()));
+            }
+        }
+        list.sort(Comparator.comparingLong(o -> o.t));
+        return list;
+    }
+
+    private void merge(List<FluxTable> tables, String col, Map<Instant, Builder> map) {
+        for (FluxTable table : tables) {
+            for (FluxRecord rec : table.getRecords()) {
+                Instant t = (Instant) rec.getValueByKey("_time");
+                Builder b = map.computeIfAbsent(t, k -> new Builder());
+                Object val = rec.getValueByKey(col);
+                switch (col) {
+                    case "o" -> b.o = toDouble(val);
+                    case "h" -> b.h = toDouble(val);
+                    case "l" -> b.l = toDouble(val);
+                    case "c" -> b.c = toDouble(val);
+                    case "v" -> b.v = toLong(val);
+                }
+            }
+        }
+    }
+
+    private static Double toDouble(Object v) { return Optional.ofNullable(v).map(x -> ((Number)x).doubleValue()).orElse(null); }
+    private static Long toLong(Object v) { return Optional.ofNullable(v).map(x -> ((Number)x).longValue()).orElse(null); }
+
+    private static class Builder {
+        Double o; Double h; Double l; Double c; Long v;
+        boolean complete(){ return o!=null && h!=null && l!=null && c!=null && v!=null; }
+        Ohlc toOhlc(String key, Instant ts){
+            return new Ohlc(key, ts.toEpochMilli(), o, h, l, c, v);
+        }
+    }
+
+    public record Ohlc(String instrumentKey,long t,double o,double h,double l,double c,long v) {}
+}

--- a/apps/api/src/main/java/com/trader/backend/util/TradingHoursUtil.java
+++ b/apps/api/src/main/java/com/trader/backend/util/TradingHoursUtil.java
@@ -1,0 +1,24 @@
+package com.trader.backend.util;
+
+import java.time.*;
+
+/** Utility to check Indian market trading hours (09:15-15:30 IST, Mon-Fri). */
+public final class TradingHoursUtil {
+    private static final ZoneId IST = ZoneId.of("Asia/Kolkata");
+    private static final LocalTime OPEN = LocalTime.of(9, 15);
+    private static final LocalTime CLOSE = LocalTime.of(15, 30);
+
+    private TradingHoursUtil() {}
+
+    public static boolean isMarketOpen(Instant now) {
+        ZonedDateTime z = now.atZone(IST);
+        DayOfWeek dow = z.getDayOfWeek();
+        if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY) return false;
+        LocalTime t = z.toLocalTime();
+        return !t.isBefore(OPEN) && !t.isAfter(CLOSE);
+    }
+
+    public static boolean isMarketOpen() {
+        return isMarketOpen(Instant.now());
+    }
+}

--- a/apps/web/src/app/models/market-status.model.ts
+++ b/apps/web/src/app/models/market-status.model.ts
@@ -1,0 +1,6 @@
+export interface MarketStatus {
+  online: boolean;
+  wsConnected: boolean;
+  lastTickTs: number;
+  reason: string;
+}

--- a/apps/web/src/app/models/ohlc.model.ts
+++ b/apps/web/src/app/models/ohlc.model.ts
@@ -1,0 +1,9 @@
+export interface Ohlc {
+  instrumentKey: string;
+  t: number;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+  v: number;
+}

--- a/apps/web/src/app/pages/dashboard/dashboard.component.html
+++ b/apps/web/src/app/pages/dashboard/dashboard.component.html
@@ -16,11 +16,12 @@
 
         <div class="panel price-panel">
           <div class="price-value">
-            {{ nowLtp === null ? '—' : (nowLtp | number:'1.2-2') }}
+            {{ (futLtp$ | async) === null ? '—' : ((futLtp$ | async) | number:'1.2-2') }}
           </div>
-          <small *ngIf="ltpSource==='live'"><span class="dot dot-live"></span>Live</small>
-          <small *ngIf="ltpSource==='influx'"><span class="dot dot-influx"></span>Last saved</small>
-          <span class="chip-live" *ngIf="marketOpen === false">Market Closed</span>
+          <small [ngClass]="(mode$ | async)==='LIVE' ? 'dot-live' : 'dot-influx'">
+            {{ mode$ | async }}
+          </small>
+          <small>Last tick {{ lastTickAge$ | async }}s ago</small>
           <div class="muted">24h <span class="rise">+0.68%</span></div>
         </div>
 

--- a/apps/web/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/web/src/app/pages/dashboard/dashboard.component.ts
@@ -10,9 +10,8 @@ import { TrustBarComponent } from './components/trust-bar/trust-bar.component';
 import { SectorTradesComponent } from './sector-trades.component';
 import { AuthService } from '../../services/auth.service';
 import { formatCountdown } from '../../utils/time';
-import { MarketDataService } from '../../services/market-data.service';
 import { AccountService } from '../../services/account.service';
-import { Subscription } from 'rxjs';
+import { DataSourceFacade } from '../../services/data-source.facade';
 
 @Component({
   selector: 'app-dashboard',
@@ -44,16 +43,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
   remaining = 0;
   polling: any;
   private countdown: any;
-  private ltpInterval: any;
-  nowLtp: number | null = null;
-  ltpTs?: string;
-  ltpSource?: 'live' | 'influx';
-  marketOpen?: boolean;
-  mainInstrument: string | null = null;
 
-  private tickSub?: Subscription;
+  mode$ = this.facade.mode$;
+  lastTickAge$ = this.facade.lastTickAge$;
+  futLtp$ = this.facade.futLtp$;
 
-  constructor(private auth: AuthService, private marketData: MarketDataService, private account: AccountService) {}
+  constructor(private auth: AuthService, private account: AccountService, private facade: DataSourceFacade) {}
 
   ngOnInit() {
     this.checkStatus();
@@ -66,29 +61,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
         }
       }
     }, 1000);
-    const stored = localStorage.getItem('mainInstrumentKey');
-    if (stored) {
-      this.initializeInstrument(stored);
-    } else {
-      this.marketData.getSelection().subscribe({
-        next: sel => {
-          if (sel?.mainInstrument) {
-            localStorage.setItem('mainInstrumentKey', sel.mainInstrument);
-            this.initializeInstrument(sel.mainInstrument);
-          } else {
-            this.initializeInstrument('NSE_FO|64103');
-          }
-        },
-        error: () => this.initializeInstrument('NSE_FO|64103'),
-      });
-    }
+    this.facade.init();
   }
 
   ngOnDestroy() {
     clearInterval(this.polling);
     clearInterval(this.countdown);
-    clearInterval(this.ltpInterval);
-    this.tickSub?.unsubscribe();
   }
 
   private checkStatus() {
@@ -119,44 +97,5 @@ export class DashboardComponent implements OnInit, OnDestroy {
   formatRemaining() {
     return formatCountdown(this.remaining);
   }
-
-  private initializeInstrument(key: string) {
-    this.mainInstrument = key;
-    this.startLtpPolling();
-    this.tickSub = this.marketData.listenTicks().subscribe(tick => {
-      if (tick.instrumentKey === this.mainInstrument && tick.ltp != null) {
-        this.nowLtp = tick.ltp;
-        this.ltpSource = 'live';
-        this.ltpTs = new Date().toISOString();
-      }
-    });
-  }
-
-  private startLtpPolling() {
-    const load = () => {
-      if (!this.mainInstrument) return;
-      this.marketData.getLtp(this.mainInstrument).subscribe({
-        next: r => {
-          if (!r || r.ltp == null) {
-            this.nowLtp = null;
-            this.ltpSource = undefined;
-            this.ltpTs = undefined;
-            return;
-          }
-          this.nowLtp = r.ltp;
-          this.ltpSource = r.source;
-          this.ltpTs = r.ts;
-        },
-        error: () => {
-          this.nowLtp = null;
-          this.ltpSource = undefined;
-          this.ltpTs = undefined;
-        },
-      });
-    };
-    load();
-    this.ltpInterval = setInterval(load, 5000);
-  }
-
 
 }

--- a/apps/web/src/app/services/data-source.facade.ts
+++ b/apps/web/src/app/services/data-source.facade.ts
@@ -1,0 +1,93 @@
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, Subscription, interval } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { MarketService } from './market.service';
+import { OhlcService } from './ohlc.service';
+import { TicksSocketService } from './ticks-socket.service';
+import { MarketDataService } from './market-data.service';
+import { Ohlc } from '../models/ohlc.model';
+
+@Injectable({ providedIn: 'root' })
+export class DataSourceFacade {
+  private market = inject(MarketService);
+  private ohlc = inject(OhlcService);
+  private socket = inject(TicksSocketService);
+  private md = inject(MarketDataService);
+
+  readonly mode$ = new BehaviorSubject<'LIVE' | 'HISTORIC'>('HISTORIC');
+  readonly ceOhlc$ = new BehaviorSubject<Ohlc[]>([]);
+  readonly peOhlc$ = new BehaviorSubject<Ohlc[]>([]);
+  readonly lastTickAge$ = new BehaviorSubject<number>(0);
+  readonly futLtp$ = new BehaviorSubject<number | null>(null);
+
+  private lastTickTs = 0;
+  private pollSub?: Subscription;
+
+  constructor() {
+    interval(1000).subscribe(() => {
+      if (this.lastTickTs > 0) {
+        this.lastTickAge$.next(Math.floor((Date.now() - this.lastTickTs) / 1000));
+      }
+    });
+    this.socket.isConnected$.subscribe(c => {
+      if (!c) {
+        this.mode$.next('HISTORIC');
+        this.startPolling();
+      }
+    });
+  }
+
+  init() {
+    this.market.getStatus().subscribe(st => {
+      this.lastTickTs = st.lastTickTs;
+      if (st.online && st.wsConnected) {
+        this.mode$.next('LIVE');
+        this.loadAndConnect();
+      } else {
+        this.mode$.next('HISTORIC');
+        this.startPolling();
+      }
+    });
+  }
+
+  private loadAndConnect() {
+    this.ohlc.getCEPE('CE').subscribe(ce => this.ceOhlc$.next(ce));
+    this.ohlc.getCEPE('PE').subscribe(pe => this.peOhlc$.next(pe));
+    this.pollSub?.unsubscribe();
+    const ceKeys = Array.from(new Set(this.ceOhlc$.getValue().map(o => o.instrumentKey)));
+    const peKeys = Array.from(new Set(this.peOhlc$.getValue().map(o => o.instrumentKey)));
+    this.md.getSelection().subscribe(sel => {
+      const fut = sel?.mainInstrument || '';
+      this.socket.connect(fut, ceKeys, peKeys);
+      this.socket.fut$.subscribe(t => { this.lastTickTs = new Date(t.ts).getTime(); this.futLtp$.next(t.ltp); });
+      this.socket.ce$.subscribe(t => this.mergeTick(this.ceOhlc$, t));
+      this.socket.pe$.subscribe(t => this.mergeTick(this.peOhlc$, t));
+    });
+  }
+
+  private startPolling() {
+    this.pollSub?.unsubscribe();
+    this.pollSub = interval(5000).pipe(
+      tap(() => {
+        this.ohlc.getCEPE('CE').subscribe(ce => this.ceOhlc$.next(ce));
+        this.ohlc.getCEPE('PE').subscribe(pe => this.peOhlc$.next(pe));
+      })
+    ).subscribe();
+  }
+
+  private mergeTick(stream: BehaviorSubject<Ohlc[]>, tick: any) {
+    const arr = [...stream.getValue()];
+    const sec = Math.floor(new Date(tick.ts).getTime() / 1000) * 1000;
+    let last = arr[arr.length - 1];
+    if (!last || last.t < sec) {
+      arr.push({ instrumentKey: tick.instrumentKey, t: sec, o: tick.ltp, h: tick.ltp, l: tick.ltp, c: tick.ltp, v: tick.volume || 0 });
+      if (arr.length > 900) arr.shift();
+    } else {
+      last.h = Math.max(last.h, tick.ltp);
+      last.l = Math.min(last.l, tick.ltp);
+      last.c = tick.ltp;
+      last.v += tick.volume || 0;
+    }
+    stream.next(arr);
+  }
+}

--- a/apps/web/src/app/services/market.service.ts
+++ b/apps/web/src/app/services/market.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable } from 'rxjs';
+import { MarketStatus } from '../models/market-status.model';
+
+@Injectable({ providedIn: 'root' })
+export class MarketService {
+  private http = inject(HttpClient);
+  private apiBase = environment.apiBase;
+
+  getStatus(): Observable<MarketStatus> {
+    return this.http.get<MarketStatus>(`${this.apiBase}/market/status`);
+    }
+}

--- a/apps/web/src/app/services/ohlc.service.ts
+++ b/apps/web/src/app/services/ohlc.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable } from 'rxjs';
+import { Ohlc } from '../models/ohlc.model';
+
+@Injectable({ providedIn: 'root' })
+export class OhlcService {
+  private http = inject(HttpClient);
+  private apiBase = environment.apiBase;
+
+  getCEPE(side: 'CE' | 'PE', gran = '1s', limit = 900): Observable<Ohlc[]> {
+    const params = new HttpParams().set('side', side).set('gran', gran).set('limit', limit);
+    return this.http.get<Ohlc[]>(`${this.apiBase}/ohlc/cepe`, { params });
+  }
+}

--- a/apps/web/src/app/services/ticks-socket.service.ts
+++ b/apps/web/src/app/services/ticks-socket.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+interface TickMsg { instrumentKey: string; ltp: number; ts: string; volume?: number; }
+
+@Injectable({ providedIn: 'root' })
+export class TicksSocketService {
+  private es: EventSource | null = null;
+  private futKey: string | null = null;
+  private ceKeys = new Set<string>();
+  private peKeys = new Set<string>();
+
+  readonly isConnected$ = new BehaviorSubject<boolean>(false);
+  private futSub = new Subject<TickMsg>();
+  private ceSub = new Subject<TickMsg>();
+  private peSub = new Subject<TickMsg>();
+  readonly fut$ = this.futSub.asObservable();
+  readonly ce$ = this.ceSub.asObservable();
+  readonly pe$ = this.peSub.asObservable();
+
+  connect(futKey: string, ceKeys: string[], peKeys: string[]) {
+    this.disconnect();
+    this.futKey = futKey;
+    this.ceKeys = new Set(ceKeys);
+    this.peKeys = new Set(peKeys);
+    const all = [futKey, ...ceKeys, ...peKeys].filter(Boolean);
+    if (!all.length) return;
+    const params = all.map(k => `instrumentKey=${encodeURIComponent(k)}`).join('&');
+    const url = `${environment.apiBase}/md/stream?${params}`;
+    this.es = new EventSource(url);
+    this.es.onopen = () => this.isConnected$.next(true);
+    this.es.onerror = () => this.isConnected$.next(false);
+    this.es.onmessage = ev => {
+      try {
+        const t = JSON.parse(ev.data) as TickMsg;
+        if (t.instrumentKey === this.futKey) this.futSub.next(t);
+        else if (this.ceKeys.has(t.instrumentKey)) this.ceSub.next(t);
+        else if (this.peKeys.has(t.instrumentKey)) this.peSub.next(t);
+      } catch {}
+    };
+  }
+
+  disconnect() {
+    this.es?.close();
+    this.es = null;
+    this.isConnected$.next(false);
+  }
+}


### PR DESCRIPTION
## Summary
- add MarketStatusService with TradingHoursUtil and expose `/market/status`
- add OHLC endpoint for CE/PE options backed by InfluxDB
- wire LiveFeedService ticks and new Angular DataSourceFacade with live/historic modes

## Testing
- `./mvnw -q test` (fails: Non-resolvable parent POM)
- `npm test` (fails: No spec files configured)


------
https://chatgpt.com/codex/tasks/task_e_68b58ecb23b8832f8879a9f857afdb15