### PR TITLE
refactor: decouple market status from live feed

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/BackendApplication.java
+++ b/apps/api/src/main/java/com/trader/backend/BackendApplication.java
@@ -1,22 +1,15 @@
 package com.trader.backend;
 
-import com.trader.backend.service.LiveFeedService;
-import com.trader.backend.service.NseInstrumentService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import javax.annotation.PostConstruct;
 
-@SpringBootApplication(scanBasePackages ="com.trader.backend")
+@SpringBootApplication(scanBasePackages = "com.trader.backend")
 @EnableScheduling
 public class BackendApplication {
 
-	@Autowired
-	private LiveFeedService liveFeedService;
-
-	public static void main(String[] args) {
-		SpringApplication.run(BackendApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
 
 }

--- a/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -11,6 +11,7 @@ import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.domain.WritePrecision;
 import com.influxdb.client.write.Point;
 import com.trader.backend.entity.NseInstrument;
+import com.trader.backend.state.MarketState;
 import com.upstox.marketdatafeederv3udapi.rpc.proto.MarketDataFeed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -70,7 +71,7 @@ public class LiveFeedService {
     private final ObjectMapper om = new ObjectMapper();
     private final MongoTemplate mongoTemplate;
     private final QuantAnalysisService quantAnalysisService;
-    private final MarketStatusService marketStatusService;
+    private final MarketState marketState;
     @Value("${app.mock:false}")
     private boolean mockMode;
 private final Sinks.Many<JsonNode> sink = Sinks.many().multicast().onBackpressureBuffer();
@@ -120,7 +121,7 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
     }
 
     public boolean isConnected() { return connected.get(); }
-    public boolean isWsConnected() { return connected.get(); }
+    public boolean isWsConnected() { return marketState.isWsConnected(); }
     public Instant lastTickTs() { return lastTickTs.get(); }
     public long ticksLast60s() { return ticksLast60s.get(); }
     public boolean futSubscribed() { return futSubscribed.get(); }
@@ -497,12 +498,27 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
 
         client.execute(URI.create(wsUrl), session ->
                 session.send(Mono.just(session.binaryMessage(bb -> bb.wrap(subFrame))))
-                        .doOnSuccess(v -> log.info("▶︎ Nifty options subscription frame sent"))
+                        .doOnSuccess(v -> {
+                            log.info("▶︎ Nifty options subscription frame sent");
+                            if (connected.compareAndSet(false, true)) {
+                                if (everConnected.getAndSet(true)) {
+                                    log.info("LIVE RECONNECTED");
+                                }
+                                log.info("LIVE CONNECTED");
+                            }
+                            marketState.setWsConnected(true);
+                        })
                         .thenMany(session.receive()
                                 .map(WebSocketMessage::getPayload)
                                 .map(this::parseProtoFeedResponse)
                                 .doOnNext(local::tryEmitNext)
                                 .doOnSubscribe(s -> log.info("📡 Subscribed to Nifty options WebSocket feed"))
+                                .doFinally(sig -> {
+                                    if (connected.getAndSet(false)) {
+                                        log.info("LIVE DISCONNECTED");
+                                    }
+                                    marketState.setWsConnected(false);
+                                })
 
                         )
                         .then()
@@ -738,7 +754,7 @@ public void streamNiftyFutAndTriggerCEPE() {
                         logLtp(instrumentKey, ltp, ts);
                         writeTickToInflux(instrumentKey, feed, ts);
                         lastTick.put(instrumentKey, new Tick(instrumentKey, ltp, Instant.ofEpochMilli(ts)));
-                        marketStatusService.onTick(ts);
+                        marketState.setLastTickTs(ts);
                         bufferOptionTick(instrumentKey, feed, ts, ltp);
 
                         if (selectionComputed.compareAndSet(false, true)) {
@@ -786,6 +802,7 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
                            log.info("LIVE CONNECTED (subs={})", total);
                        }
                        optSubscribedCount.set(subsCount);
+                       marketState.setWsConnected(true);
                    })
                    .thenMany(session.receive()
                            .map(WebSocketMessage::getPayload)
@@ -796,6 +813,7 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
                                    log.info("LIVE DISCONNECTED");
                                }
                                optSubscribedCount.set(0);
+                               marketState.setWsConnected(false);
                            }))
                    .then()
     ).subscribe();
@@ -853,6 +871,7 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
         lastTick.clear();
         optionBuffers.clear();
         connected.set(false);
+        marketState.setWsConnected(false);
         futSubscribed.set(false);
         optSubscribedCount.set(0);
     }

--- a/apps/api/src/main/java/com/trader/backend/service/MarketStatusService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/MarketStatusService.java
@@ -1,11 +1,11 @@
 package com.trader.backend.service;
 
+import com.trader.backend.state.MarketState;
 import com.trader.backend.util.TradingHoursUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Tracks live market connection state and last tick timestamp.
@@ -14,19 +14,21 @@ import java.util.concurrent.atomic.AtomicLong;
 @RequiredArgsConstructor
 public class MarketStatusService {
 
-    private final LiveFeedService liveFeedService;
-    private final AtomicLong lastTickTs = new AtomicLong(0);
+    private final MarketState marketState;
 
+    /**
+     * Update the timestamp of the latest received tick.
+     */
     public void onTick(long ts) {
-        lastTickTs.set(ts);
+        marketState.setLastTickTs(ts);
     }
 
     public Status getStatus() {
-        boolean wsConnected = liveFeedService.isWsConnected();
+        boolean wsConnected = marketState.isWsConnected();
         boolean open = TradingHoursUtil.isMarketOpen(Instant.now());
         boolean online = open && wsConnected;
         String reason = online ? "" : (open ? "ws-disconnected" : "market-closed");
-        return new Status(online, wsConnected, lastTickTs.get(), reason);
+        return new Status(online, wsConnected, marketState.getLastTickTs(), reason);
     }
 
     public record Status(boolean online, boolean wsConnected, long lastTickTs, String reason) {}

--- a/apps/api/src/main/java/com/trader/backend/state/MarketState.java
+++ b/apps/api/src/main/java/com/trader/backend/state/MarketState.java
@@ -1,0 +1,33 @@
+package com.trader.backend.state;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Shared mutable market state. Holds WebSocket connection status and
+ * timestamp of the last received tick.
+ */
+@Component
+public class MarketState {
+
+    private final AtomicBoolean wsConnected = new AtomicBoolean(false);
+    private final AtomicLong lastTickTs = new AtomicLong(0);
+
+    public boolean isWsConnected() {
+        return wsConnected.get();
+    }
+
+    public void setWsConnected(boolean connected) {
+        wsConnected.set(connected);
+    }
+
+    public long getLastTickTs() {
+        return lastTickTs.get();
+    }
+
+    public void setLastTickTs(long ts) {
+        lastTickTs.set(ts);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce neutral `MarketState` bean to hold WebSocket state and last tick timestamp
- refactor `MarketStatusService` and `LiveFeedService` to use `MarketState`, eliminating circular dependency
- remove unused `LiveFeedService` injection from `BackendApplication`

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a7bafa4c832f9802f65a0059a0e9