### PR TITLE
Implement global CORS and proper unauthorized responses

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -1,48 +1,61 @@
 package com.trader.backend.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import java.util.Arrays;
 import java.util.List;
-@ComponentScan
+import java.util.stream.Collectors;
+
+/**
+ * Global CORS configuration for all REST endpoints. The allowed origins can be
+ * overridden via the {@code ALLOWED_ORIGINS} environment variable (comma
+ * separated). Defaults to the Vercel frontend.
+ */
 @Configuration
-@EnableWebMvc
 public class CorsConfig {
 
-    @Value("${cors.allowedOrigins:https://combinedfrontendbackend.vercel.app,http://localhost:4200}")
+    @Value("${ALLOWED_ORIGINS:https://combinedfrontendbackend.vercel.app}")
     private String allowedOrigins;
 
     @Bean
-    public CorsFilter corsFilter() {
+    public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(false);
-        config.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
-        config.setAllowedHeaders(List.of("Content-Type"));
-        config.setAllowedMethods(List.of("GET"));
+
+        List<String> origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+
+        config.setAllowedOrigins(origins);
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of(
+                "Authorization",
+                "Content-Type",
+                "X-Requested-With",
+                "Accept",
+                "Origin"));
+        config.setExposedHeaders(List.of("Location", "Link", "Content-Disposition"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        List<String> paths = List.of(
-                "/auth/**",
-                "/md/selection",
-                "/md/candles",
-                "/md/stream",
-                "/md/last-ltp",
-                "/md/ltp",
-                "/md/sector-trades",
-                "/ops/live-status",
-                "/ops/influx-sanity",
-                "/ops/market-clock",
-                "/ops/upstox-balance"
-        );
-        paths.forEach(p -> source.registerCorsConfiguration(p, config));
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
 
-        return new CorsFilter(source);
+    @Bean
+    public FilterRegistrationBean<CorsFilter> corsFilter(CorsConfigurationSource source) {
+        FilterRegistrationBean<CorsFilter> bean = new FilterRegistrationBean<>(new CorsFilter(source));
+        bean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return bean;
     }
 }
+

--- a/apps/api/src/main/java/com/trader/backend/controller/OpsController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/OpsController.java
@@ -4,8 +4,11 @@ import com.trader.backend.service.MarketHours;
 import com.trader.backend.service.LiveFeedService;
 import com.trader.backend.service.InfluxTickService;
 import com.trader.backend.service.UpstoxAuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.*;
 import java.util.LinkedHashMap;
@@ -77,8 +80,15 @@ public class OpsController {
     }
 
     @GetMapping("/ops/upstox-balance")
-    public Mono<Map<String, Object>> upstoxBalance() {
+    public Mono<ResponseEntity<Map<String, Object>>> upstoxBalance() {
         return upstoxAuthService.fetchBalance()
-                .map(bal -> Map.of("balance", bal));
+                .map(bal -> ResponseEntity.ok(Map.of("balance", bal)))
+                .onErrorResume(ResponseStatusException.class, e -> {
+                    if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+                        return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                                .body(Map.of("error", "unauthorized")));
+                    }
+                    return Mono.error(e);
+                });
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -16,6 +17,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
+import org.springframework.web.server.ResponseStatusException;
 import java.util.Base64;
 
 import javax.annotation.PostConstruct;
@@ -294,9 +296,9 @@ public class UpstoxAuthService {
     /** Fetch the user's available cash balance from Upstox. */
     public Mono<Double> fetchBalance() {
         String token = accessToken.get();
-        if (token == null) {
+        if (token == null || token.isBlank()) {
             log.warn("Access-token not ready. Hit /auth/exchange first.");
-            return Mono.just(0.0);
+            return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
         }
 
         return webClient.get()
@@ -304,6 +306,11 @@ public class UpstoxAuthService {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .retrieve()
+                .onStatus(status -> status.value() == 401,
+                        resp -> {
+                            log.warn("Upstox API responded 401 for balance fetch");
+                            return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
+                        })
                 .bodyToMono(JsonNode.class)
                 .map(j -> j.at("/data/equity/available_margin").asDouble(0.0));
     }

--- a/apps/api/src/main/resources/application.properties
+++ b/apps/api/src/main/resources/application.properties
@@ -68,4 +68,3 @@ logging.level.root=INFO
 
 
 # --- UI CORS ---
-cors.allowedOrigins=https://combinedfrontendbackend.vercel.app


### PR DESCRIPTION
## Summary
- configure global CORS using `ALLOWED_ORIGINS` env var and expose standard headers
- return 401 JSON error when Upstox balance is requested without a valid token
- remove legacy per-path CORS property

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network is unreachable)*
- `curl -i -X OPTIONS "https://combinedfrontendbackend-production.up.railway.app/market/status" -H "Origin: https://combinedfrontendbackend.vercel.app" -H "Access-Control-Request-Method: GET"` *(403 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b9cbbe50832faecbd263f037b119