### PR TITLE
feat: add depth imbalance signal engine

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -30,3 +30,24 @@ frontend. The current value can be retrieved from the backend at
 For CORS, adjust the `cors.allowedOrigins` property if you need to allow
 additional origins. By default it allows the deployed Vercel domain and
 `http://localhost:4200` for local development.
+
+## DBI5 Signal Engine
+
+The backend aggregates the top-five bid and ask levels to compute a Depth
+Bid-Ask Imbalance (DBI5) value. When this imbalance persists for 800 ms and
+exceeds configured thresholds, a `BUY_CE` or `BUY_PE` signal is emitted with
+suggested stop-loss and take-profit prices.
+
+### Streaming signals
+
+Signals are exposed as Server Sent Events:
+
+```bash
+curl http://localhost:8080/signals/live
+```
+
+Each event payload has the schema:
+
+```json
+{"ts":"2025-09-01T19:19:58.252806Z","symbol":"TEST","side":"BUY_CE","dbi":2.0,"sl":85.0,"tp":125.0}
+```

--- a/apps/api/pom.xml
+++ b/apps/api/pom.xml
@@ -180,6 +180,26 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.10</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- OS detection, needed for protoc classifier -->
             <plugin>
                 <groupId>kr.motd.maven</groupId>

--- a/apps/api/src/main/java/com/trader/backend/BackendApplication.java
+++ b/apps/api/src/main/java/com/trader/backend/BackendApplication.java
@@ -2,10 +2,14 @@ package com.trader.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import com.trader.backend.config.SignalsProperties;
 
 @SpringBootApplication(scanBasePackages = "com.trader.backend")
 @EnableScheduling
+@EnableConfigurationProperties(SignalsProperties.class)
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/apps/api/src/main/java/com/trader/backend/config/SignalsProperties.java
+++ b/apps/api/src/main/java/com/trader/backend/config/SignalsProperties.java
@@ -1,0 +1,48 @@
+package com.trader.backend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration knobs for depth-based signal generation.
+ */
+@ConfigurationProperties(prefix = "signals")
+public class SignalsProperties {
+    /** maximum depth levels to consider per side */
+    private int maxLevels = 5;
+    /** sampling window in milliseconds */
+    private int windowMs = 100;
+    /** required persistence in milliseconds */
+    private int persistMs = 800;
+    /** master switch for engine */
+    private boolean enabled = true;
+
+    public int getMaxLevels() {
+        return maxLevels;
+    }
+    public void setMaxLevels(int maxLevels) {
+        this.maxLevels = maxLevels;
+    }
+    public int getWindowMs() {
+        return windowMs;
+    }
+    public void setWindowMs(int windowMs) {
+        this.windowMs = windowMs;
+    }
+    public int getPersistMs() {
+        return persistMs;
+    }
+    public void setPersistMs(int persistMs) {
+        this.persistMs = persistMs;
+    }
+    public boolean isEnabled() {
+        return enabled;
+    }
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /** number of consecutive windows required */
+    public int getPersistWindows() {
+        return persistMs / windowMs;
+    }
+}

--- a/apps/api/src/main/java/com/trader/backend/controller/SignalController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/SignalController.java
@@ -1,0 +1,35 @@
+package com.trader.backend.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trader.backend.events.SignalEvent;
+import com.trader.backend.service.SignalEngine;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+/**
+ * Server Sent Events endpoint exposing live trading signals.
+ */
+@RestController
+@RequiredArgsConstructor
+public class SignalController {
+
+    private final SignalEngine engine;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @GetMapping(value = "/signals/live", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<String> live() {
+        return engine.stream().map(this::toJson);
+    }
+
+    private String toJson(SignalEvent ev) {
+        try {
+            return mapper.writeValueAsString(ev);
+        } catch (JsonProcessingException e) {
+            return "{}";
+        }
+    }
+}

--- a/apps/api/src/main/java/com/trader/backend/events/SignalEvent.java
+++ b/apps/api/src/main/java/com/trader/backend/events/SignalEvent.java
@@ -1,0 +1,8 @@
+package com.trader.backend.events;
+
+import java.time.Instant;
+
+/**
+ * Emitted when depth imbalance indicates a directional trade signal.
+ */
+public record SignalEvent(Instant ts, String symbol, String side, double dbi, double sl, double tp) {}

--- a/apps/api/src/main/java/com/trader/backend/service/DepthMetricsService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/DepthMetricsService.java
@@ -1,0 +1,76 @@
+package com.trader.backend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.trader.backend.config.SignalsProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Computes depth based metrics such as the Depth Bid-Ask Imbalance (DBI5)
+ * from streaming order book snapshots.
+ */
+@Service
+@RequiredArgsConstructor
+public class DepthMetricsService {
+
+    private final SignalsProperties props;
+    private final Sinks.Many<DepthTick> sink = Sinks.many().multicast().onBackpressureBuffer();
+
+    /**
+     * Accepts a raw feed payload and publishes a structured depth tick.
+     */
+    public void onFeed(String symbol, JsonNode feed, double ltp, Instant ts) {
+        JsonNode quotes = feed.path("fullFeed").path("marketFF").path("marketLevel").path("bidAskQuote");
+        List<Level> bids = new ArrayList<>();
+        List<Level> asks = new ArrayList<>();
+        if (quotes.isArray()) {
+            int max = Math.min(props.getMaxLevels(), quotes.size());
+            for (int i = 0; i < max; i++) {
+                JsonNode level = quotes.get(i);
+                bids.add(new Level(level.path("bidP").asDouble(0), level.path("bidQ").asDouble(0)));
+                asks.add(new Level(level.path("askP").asDouble(0), level.path("askQ").asDouble(0)));
+            }
+        }
+        onDepthTick(new DepthTick(symbol, bids, asks, ltp, ts));
+    }
+
+    /**
+     * Publishes a structured depth tick.
+     */
+    public void onDepthTick(DepthTick tick) {
+        sink.tryEmitNext(tick);
+    }
+
+    /**
+     * Stream of DBI5 metrics per symbol sampled at the configured window.
+     */
+    public Flux<DepthMetric> metrics() {
+        return sink.asFlux()
+                .groupBy(DepthTick::symbol)
+                .flatMap(g -> g.sample(Duration.ofMillis(props.getWindowMs()))
+                        .map(this::computeMetric));
+    }
+
+    private DepthMetric computeMetric(DepthTick t) {
+        int n = Math.min(props.getMaxLevels(), Math.min(t.bids().size(), t.asks().size()));
+        double bidSum = 0;
+        double askSum = 0;
+        for (int i = 0; i < n; i++) {
+            bidSum += t.bids().get(i).qty();
+            askSum += t.asks().get(i).qty();
+        }
+        double dbi = askSum == 0 ? 0 : bidSum / askSum;
+        return new DepthMetric(t.symbol(), dbi, t.ltp(), t.ts());
+    }
+
+    public record Level(double price, double qty) { }
+    public record DepthTick(String symbol, List<Level> bids, List<Level> asks, double ltp, Instant ts) { }
+    public record DepthMetric(String symbol, double dbi, double ltp, Instant ts) { }
+}

--- a/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -72,6 +72,7 @@ public class LiveFeedService {
     private final MongoTemplate mongoTemplate;
     private final QuantAnalysisService quantAnalysisService;
     private final MarketState marketState;
+    private final DepthMetricsService depthMetricsService;
     @Value("${app.mock:false}")
     private boolean mockMode;
 private final Sinks.Many<JsonNode> sink = Sinks.many().multicast().onBackpressureBuffer();
@@ -623,6 +624,8 @@ public void streamFilteredNiftyOptions() {
                     lastTick.put(instrumentKey, new Tick(instrumentKey, ltp, Instant.ofEpochMilli(ts)));
                     bufferOptionTick(instrumentKey, feed, ts, ltp);
 
+                    depthMetricsService.onFeed(instrumentKey, feed, ltp, Instant.ofEpochMilli(ts));
+
                     var result = quantAnalysisService.analyze(instrumentKey, feed);
                     if (result.signal() != QuantAnalysisService.Signal.NONE) {
                         log.info("🎯 {} for {} → momentum={} volSpike={} imbalance={} noise={}",
@@ -677,9 +680,11 @@ JsonNode ltpNode = tick.path("feeds")
                     long ts = extractTimestamp(tick.path("feeds").path(instrumentKey), tick);
                     logLtp(instrumentKey, ltp, ts);
                     ltpSink.tryEmitNext(new LtpEvent(instrumentKey, ltp, Instant.ofEpochMilli(ts)));
-                    writeTickToInflux(instrumentKey, tick.path("feeds").path(instrumentKey), ts);
+                    JsonNode singleFeed = tick.path("feeds").path(instrumentKey);
+                    writeTickToInflux(instrumentKey, singleFeed, ts);
                     lastTick.put(instrumentKey, new Tick(instrumentKey, ltp, Instant.ofEpochMilli(ts)));
-                    bufferOptionTick(instrumentKey, tick.path("feeds").path(instrumentKey), ts, ltp);
+                    bufferOptionTick(instrumentKey, singleFeed, ts, ltp);
+                    depthMetricsService.onFeed(instrumentKey, singleFeed, ltp, Instant.ofEpochMilli(ts));
                 }
 
                 sink.tryEmitNext(tick);

--- a/apps/api/src/main/java/com/trader/backend/service/SignalEngine.java
+++ b/apps/api/src/main/java/com/trader/backend/service/SignalEngine.java
@@ -1,0 +1,69 @@
+package com.trader.backend.service;
+
+import com.trader.backend.config.SignalsProperties;
+import com.trader.backend.events.SignalEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+import jakarta.annotation.PostConstruct;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Consumes depth metrics and emits trading signals once configured
+ * thresholds persist for the desired duration.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SignalEngine {
+
+    private final DepthMetricsService depthMetricsService;
+    private final SignalsProperties props;
+    private final Sinks.Many<SignalEvent> sink = Sinks.many().multicast().onBackpressureBuffer();
+
+    private static class Counts { int ce; int pe; }
+    private final Map<String, Counts> state = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    void init() {
+        depthMetricsService.metrics().subscribe(this::handleMetric);
+    }
+
+    private void handleMetric(DepthMetricsService.DepthMetric metric) {
+        if (!props.isEnabled()) return;
+        int required = props.getPersistWindows();
+        Counts c = state.computeIfAbsent(metric.symbol(), k -> new Counts());
+        if (metric.dbi() > 1.8) {
+            c.ce++; c.pe = 0;
+            if (c.ce >= required) {
+                emit("BUY_CE", metric);
+                c.ce = 0;
+            }
+        } else if (metric.dbi() < 0.55) {
+            c.pe++; c.ce = 0;
+            if (c.pe >= required) {
+                emit("BUY_PE", metric);
+                c.pe = 0;
+            }
+        } else {
+            c.ce = 0; c.pe = 0;
+        }
+    }
+
+    private void emit(String side, DepthMetricsService.DepthMetric m) {
+        double sl = m.ltp() * 0.85;  // -15%
+        double tp = m.ltp() * 1.25;  // +25%
+        SignalEvent ev = new SignalEvent(Instant.now(), m.symbol(), side, m.dbi(), sl, tp);
+        sink.tryEmitNext(ev);
+        log.info("Signal {} for {} dbi={}", side, m.symbol(), m.dbi());
+    }
+
+    public Flux<SignalEvent> stream() {
+        return sink.asFlux();
+    }
+}

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+signals:
+  maxLevels: 5
+  windowMs: 100
+  persistMs: 800
+  enabled: true

--- a/apps/api/src/test/java/com/trader/backend/service/DepthMetricsServiceTest.java
+++ b/apps/api/src/test/java/com/trader/backend/service/DepthMetricsServiceTest.java
@@ -1,0 +1,107 @@
+package com.trader.backend.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.trader.backend.config.SignalsProperties;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DepthMetricsServiceTest {
+
+    private DepthMetricsService service(SignalsProperties props) {
+        return new DepthMetricsService(props);
+    }
+
+    @Test
+    void computesDbiCorrectly() {
+        SignalsProperties p = new SignalsProperties();
+        p.setWindowMs(10);
+        DepthMetricsService svc = service(p);
+        var bids = List.of(new DepthMetricsService.Level(100, 10),
+                new DepthMetricsService.Level(99, 10),
+                new DepthMetricsService.Level(98, 10),
+                new DepthMetricsService.Level(97, 10),
+                new DepthMetricsService.Level(96, 10));
+        var asks = List.of(new DepthMetricsService.Level(101, 5),
+                new DepthMetricsService.Level(102, 5),
+                new DepthMetricsService.Level(103, 5),
+                new DepthMetricsService.Level(104, 5),
+                new DepthMetricsService.Level(105, 5));
+        svc.onDepthTick(new DepthMetricsService.DepthTick("SYM", bids, asks, 100, Instant.now()));
+        StepVerifier.withVirtualTime(svc::metrics)
+                .thenAwait(Duration.ofMillis(20))
+                .expectNextMatches(m -> Math.abs(m.dbi() - 2.0) < 1e-6)
+                .thenCancel()
+                .verify();
+    }
+
+    @Test
+    void respectsMaxLevels() {
+        SignalsProperties p = new SignalsProperties();
+        p.setWindowMs(10);
+        p.setMaxLevels(2);
+        DepthMetricsService svc = service(p);
+        var bids = List.of(new DepthMetricsService.Level(100, 10),
+                new DepthMetricsService.Level(99, 10),
+                new DepthMetricsService.Level(98, 10));
+        var asks = List.of(new DepthMetricsService.Level(101, 5),
+                new DepthMetricsService.Level(102, 5),
+                new DepthMetricsService.Level(103, 5));
+        svc.onDepthTick(new DepthMetricsService.DepthTick("SYM", bids, asks, 100, Instant.now()));
+        StepVerifier.withVirtualTime(svc::metrics)
+                .thenAwait(Duration.ofMillis(20))
+                .expectNextMatches(m -> Math.abs(m.dbi() - 4.0) < 1e-6) // (10+10)/(5+5)
+                .thenCancel()
+                .verify();
+    }
+
+    @Test
+    void parsesJsonFeed() {
+        SignalsProperties p = new SignalsProperties();
+        p.setWindowMs(10);
+        DepthMetricsService svc = service(p);
+        ObjectMapper om = new ObjectMapper();
+        ObjectNode feed = om.createObjectNode();
+        ObjectNode full = feed.putObject("fullFeed").putObject("marketFF")
+                .putObject("marketLevel");
+        ArrayNode arr = full.putArray("bidAskQuote");
+        for (int i = 0; i < 5; i++) {
+            ObjectNode lvl = arr.addObject();
+            lvl.put("bidP", 100 - i);
+            lvl.put("bidQ", 10);
+            lvl.put("askP", 101 + i);
+            lvl.put("askQ", 5);
+        }
+        svc.onFeed("SYM", feed, 100, Instant.now());
+        StepVerifier.withVirtualTime(svc::metrics)
+                .thenAwait(Duration.ofMillis(20))
+                .expectNextMatches(m -> Math.abs(m.dbi() - 2.0) < 1e-6)
+                .thenCancel()
+                .verify();
+    }
+
+    @Test
+    void emitsPerWindow() {
+        SignalsProperties p = new SignalsProperties();
+        p.setWindowMs(10);
+        DepthMetricsService svc = service(p);
+        var bids = List.of(new DepthMetricsService.Level(100, 10));
+        var asks = List.of(new DepthMetricsService.Level(101, 5));
+        Flux.interval(Duration.ofMillis(10)).take(3)
+                .doOnNext(i -> svc.onDepthTick(new DepthMetricsService.DepthTick("X", bids, asks, 100, Instant.now())))
+                .subscribe();
+        StepVerifier.withVirtualTime(svc::metrics)
+                .thenAwait(Duration.ofMillis(40))
+                .expectNextCount(3)
+                .thenCancel()
+                .verify();
+    }
+}

--- a/apps/api/src/test/java/com/trader/backend/service/SignalEngineTest.java
+++ b/apps/api/src/test/java/com/trader/backend/service/SignalEngineTest.java
@@ -1,0 +1,105 @@
+package com.trader.backend.service;
+
+import com.trader.backend.config.SignalsProperties;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class SignalEngineTest {
+
+    private DepthMetricsService service(SignalsProperties p) {
+        return new DepthMetricsService(p);
+    }
+
+    private DepthMetricsService.DepthTick tickHigh() {
+        var bids = List.of(new DepthMetricsService.Level(100, 20),
+                new DepthMetricsService.Level(99, 20),
+                new DepthMetricsService.Level(98, 20),
+                new DepthMetricsService.Level(97, 20),
+                new DepthMetricsService.Level(96, 20));
+        var asks = List.of(new DepthMetricsService.Level(101, 10),
+                new DepthMetricsService.Level(102, 10),
+                new DepthMetricsService.Level(103, 10),
+                new DepthMetricsService.Level(104, 10),
+                new DepthMetricsService.Level(105, 10));
+        return new DepthMetricsService.DepthTick("SYM", bids, asks, 100, Instant.now());
+    }
+
+    private DepthMetricsService.DepthTick tickLow() {
+        var bids = List.of(new DepthMetricsService.Level(100, 5),
+                new DepthMetricsService.Level(99, 5),
+                new DepthMetricsService.Level(98, 5),
+                new DepthMetricsService.Level(97, 5),
+                new DepthMetricsService.Level(96, 5));
+        var asks = List.of(new DepthMetricsService.Level(101, 20),
+                new DepthMetricsService.Level(102, 20),
+                new DepthMetricsService.Level(103, 20),
+                new DepthMetricsService.Level(104, 20),
+                new DepthMetricsService.Level(105, 20));
+        return new DepthMetricsService.DepthTick("SYM", bids, asks, 100, Instant.now());
+    }
+
+    @Test
+    void buyCeAfterPersistence() {
+        SignalsProperties p = new SignalsProperties();
+        p.setWindowMs(10);
+        p.setPersistMs(80);
+        DepthMetricsService svc = service(p);
+        SignalEngine engine = new SignalEngine(svc, p);
+        StepVerifier.withVirtualTime(engine::stream)
+                .then(() -> Flux.interval(Duration.ofMillis(10)).take(8).subscribe(i -> svc.onDepthTick(tickHigh())))
+                .thenAwait(Duration.ofMillis(80))
+                .expectNextMatches(ev -> ev.side().equals("BUY_CE"))
+                .thenCancel()
+                .verify();
+    }
+
+    @Test
+    void buyPeAfterPersistence() {
+        SignalsProperties p = new SignalsProperties();
+        p.setWindowMs(10);
+        p.setPersistMs(80);
+        DepthMetricsService svc = service(p);
+        SignalEngine engine = new SignalEngine(svc, p);
+        StepVerifier.withVirtualTime(engine::stream)
+                .then(() -> Flux.interval(Duration.ofMillis(10)).take(8).subscribe(i -> svc.onDepthTick(tickLow())))
+                .thenAwait(Duration.ofMillis(80))
+                .expectNextMatches(ev -> ev.side().equals("BUY_PE"))
+                .thenCancel()
+                .verify();
+    }
+
+    @Test
+    void noSignalWithoutPersistence() {
+        SignalsProperties p = new SignalsProperties();
+        p.setWindowMs(10);
+        p.setPersistMs(80);
+        DepthMetricsService svc = service(p);
+        SignalEngine engine = new SignalEngine(svc, p);
+        StepVerifier.withVirtualTime(engine::stream)
+                .then(() -> Flux.interval(Duration.ofMillis(10)).take(7).subscribe(i -> svc.onDepthTick(tickHigh())))
+                .thenAwait(Duration.ofMillis(70))
+                .expectTimeout(Duration.ofMillis(10))
+                .verify();
+    }
+
+    @Test
+    void replayThirtySeconds() {
+        SignalsProperties p = new SignalsProperties();
+        p.setWindowMs(100);
+        p.setPersistMs(800);
+        DepthMetricsService svc = service(p);
+        SignalEngine engine = new SignalEngine(svc, p);
+        StepVerifier.withVirtualTime(engine::stream)
+                .then(() -> Flux.interval(Duration.ofMillis(100)).take(300).subscribe(i -> svc.onDepthTick(tickHigh())))
+                .thenAwait(Duration.ofSeconds(30))
+                .expectNextMatches(ev -> ev.side().equals("BUY_CE"))
+                .thenCancel()
+                .verify();
+    }
+}


### PR DESCRIPTION
## Summary
- compute DBI5 from top-of-book levels and stream metrics
- emit BUY_CE/BUY_PE after 800 ms persistence with SL/TP suggestions
- expose `GET /signals/live` SSE endpoint and document usage

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ee132260832fb09392c8b09234a0