### PR TITLE
build: support offline maven workflow

### DIFF
--- a/.github/workflows/offline-build.yml
+++ b/.github/workflows/offline-build.yml
@@ -1,0 +1,44 @@
+name: Offline Maven Build
+
+on:
+  push:
+    paths:
+      - 'apps/api/**'
+      - '.github/workflows/offline-build.yml'
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - '.github/workflows/offline-build.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+      - name: Prime dependencies
+        run: ./mvnw -B -DskipTests dependency:go-offline
+      - name: Build offline
+        run: ./mvnw -q -o -Poffline-ready -DskipTests package
+      - name: Start application
+        run: |
+          java -jar target/*.jar &
+          echo $! > build.pid
+          sleep 15
+      - name: Curl upstox balance
+        run: curl -i http://localhost:8080/ops/upstox-balance || true
+      - name: Stop application
+        if: always()
+        run: |
+          kill $(cat build.pid) || true

--- a/BUILD_OFFLINE.md
+++ b/BUILD_OFFLINE.md
@@ -1,0 +1,41 @@
+# Offline Build Guide
+
+This project ships with a Maven wrapper and a local `settings.xml` that defines a mirror for Maven Central and an `offline-ready` profile.  Once the dependency cache is warmed, the project can be built without internet access.
+
+## 1. Prime the Maven cache (online)
+
+```bash
+cd apps/api
+./mvnw -B -DskipTests dependency:go-offline
+# Optional: archive ~/.m2 as m2-cache-<commit>
+```
+
+## 2. Restore and build offline
+
+```bash
+# Restore the archived ~/.m2 directory if needed
+cd apps/api
+./mvnw -q -o -Poffline-ready -DskipTests package
+```
+
+The fat JAR is generated under `apps/api/target/`.
+
+## 3. Run and verify an endpoint
+
+```bash
+java -jar target/*.jar &
+sleep 10
+curl -i http://localhost:8080/ops/upstox-balance
+```
+
+The unauthenticated request returns HTTP 401 with body:
+
+```json
+{"error":"unauthorized"}
+```
+
+## 4. Toggling online/offline
+
+- **Online build:** `./mvnw -DskipTests package`
+- **Offline build:** `./mvnw -q -o -Poffline-ready -DskipTests package`
+

--- a/apps/api/.mvn/settings.xml
+++ b/apps/api/.mvn/settings.xml
@@ -1,5 +1,50 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <!-- Proxy configuration removed to avoid failing builds in environments without a local proxy. -->
+  <mirrors>
+    <mirror>
+      <id>repo1</id>
+      <name>Maven Central Mirror</name>
+      <url>https://repo1.maven.org/maven2</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+    <!-- Optional private mirror; set PRIVATE_MAVEN_MIRROR to enable -->
+    <mirror>
+      <id>private</id>
+      <url>${env.PRIVATE_MAVEN_MIRROR}</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+  <profiles>
+    <profile>
+      <id>offline-ready</id>
+      <properties>
+        <wagon.http.retryHandler.count>3</wagon.http.retryHandler.count>
+        <wagon.http.connectTimeout>5000</wagon.http.connectTimeout>
+      </properties>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+          <id>central-fallback</id>
+          <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+        </pluginRepository>
+        <pluginRepository>
+          <id>central-fallback</id>
+          <url>https://repo.maven.apache.org/maven2</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>offline-ready</activeProfile>
+  </activeProfiles>
 </settings>

--- a/apps/api/src/main/java/com/trader/backend/controller/OpsController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/OpsController.java
@@ -82,11 +82,11 @@ public class OpsController {
     @GetMapping("/ops/upstox-balance")
     public Mono<ResponseEntity<Map<String, Object>>> upstoxBalance() {
         return upstoxAuthService.fetchBalance()
-                .map(bal -> ResponseEntity.ok(Map.of("balance", bal)))
+                .map(bal -> ResponseEntity.ok(Map.<String, Object>of("balance", bal)))
                 .onErrorResume(ResponseStatusException.class, e -> {
                     if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
                         return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                                .body(Map.of("error", "unauthorized")));
+                                .body(Map.<String, Object>of("error", "unauthorized")));
                     }
                     return Mono.error(e);
                 });

--- a/scripts/prime-m2.sh
+++ b/scripts/prime-m2.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prime the Maven local repository with all dependencies for offline builds.
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+PROJECT_ROOT="$SCRIPT_DIR/../apps/api"
+
+cd "$PROJECT_ROOT"
+./mvnw -B -DskipTests dependency:go-offline


### PR DESCRIPTION
## Summary
- add project `settings.xml` with central mirror and `offline-ready` profile
- document steps for priming and offline builds
- add GitHub Actions workflow and helper script to cache dependencies for offline Maven builds

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `scripts/prime-m2.sh` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f5c75cb0832fb1f0dbe10643bbf4