### PR TITLE
build: support offline maven workflow

### DIFF
--- a/.github/workflows/build-offline.yml
+++ b/.github/workflows/build-offline.yml
@@ -1,0 +1,80 @@
+name: Offline Maven Build
+
+on:
+  push:
+    paths:
+      - 'apps/api/**'
+      - '.github/workflows/build-offline.yml'
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - '.github/workflows/build-offline.yml'
+
+jobs:
+  prime-cache:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Prime dependencies
+        run: ./mvnw -B -DskipTests dependency:go-offline
+      - name: Print resolved dependencies
+        run: ./mvnw -B -DskipTests -Poffline-ready help:evaluate -Dexpression=project.dependencies
+      - name: Archive Maven repository
+        run: |
+          tar -C ~/.m2 -c repository | zstd -T0 > m2-cache-${{ github.sha }}.tar.zst
+      - uses: actions/upload-artifact@v4
+        with:
+          name: m2-cache
+          path: m2-cache-${{ github.sha }}.tar.zst
+
+  build-offline:
+    needs: prime-cache
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      MAVEN_OPTS: -Djava.net.preferIPv4Stack=true
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: actions/download-artifact@v4
+        with:
+          name: m2-cache
+      - name: Extract Maven repository
+        run: |
+          mkdir -p ~/.m2
+          tar --use-compress-program=unzstd -xf m2-cache-*.tar.zst -C ~/.m2
+      - name: Offline package build
+        run: ./mvnw -q -o -DskipTests package
+      - name: Start application
+        run: |
+          java -jar target/*.jar > app.log 2>&1 &
+          echo $! > app.pid
+          sleep 7
+      - name: Curl upstox balance
+        run: |
+          curl -i --max-time 5 http://localhost:8080/ops/upstox-balance > curl.log 2>&1 || true
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: offline-logs
+          path: |
+            app.log
+            curl.log
+      - name: Stop application
+        if: always()
+        run: |
+          kill $(cat app.pid) || true

--- a/BUILD_OFFLINE.md
+++ b/BUILD_OFFLINE.md
@@ -1,0 +1,45 @@
+# Offline Build Guide
+
+This project uses the Maven wrapper and a local `settings.xml` that defines a mirror for Maven Central and an `offline-ready` profile. Once the dependency cache is warmed, the project can be built without internet access.
+
+## 1. Prime the Maven cache (online)
+
+```bash
+scripts/prime-m2.sh       # downloads all dependencies
+# archive the cache for reuse
+tar -C ~/.m2 -c repository | zstd -T0 > m2-cache-$(git rev-parse HEAD).tar.zst
+```
+
+## 2. Restore and build offline
+
+```bash
+# Extract previously archived cache
+mkdir -p ~/.m2 && tar --use-compress-program=unzstd -xf m2-cache-<commit>.tar.zst -C ~/.m2
+cd apps/api
+./mvnw -q -o -Poffline-ready -DskipTests package
+```
+
+The fat JAR is generated under `apps/api/target/`.
+
+## 3. Run and verify an endpoint
+
+```bash
+java -jar target/*.jar &
+sleep 10
+curl -i http://localhost:8080/ops/upstox-balance
+```
+
+The unauthenticated request returns HTTP 401 with body:
+
+```json
+{"error":"unauthorized"}
+```
+
+## 4. Toggling online/offline
+
+- **Online build:** `./mvnw -DskipTests package`
+- **Offline build:** `./mvnw -q -o -Poffline-ready -DskipTests package`
+
+## 5. Re-priming the cache
+
+When dependencies change, rerun `scripts/prime-m2.sh` and archive the new `~/.m2/repository`.

--- a/apps/api/.mvn/settings.xml
+++ b/apps/api/.mvn/settings.xml
@@ -1,5 +1,51 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <!-- Proxy configuration removed to avoid failing builds in environments without a local proxy. -->
+  <mirrors>
+    <mirror>
+      <id>repo1</id>
+      <name>Maven Central Mirror</name>
+      <url>https://repo1.maven.org/maven2</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+    <!-- Optional private mirror; set PRIVATE_MAVEN_MIRROR to enable -->
+    <mirror>
+      <id>private</id>
+      <url>${env.PRIVATE_MAVEN_MIRROR}</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+  <profiles>
+    <profile>
+      <id>offline-ready</id>
+      <properties>
+        <wagon.http.retryHandler.count>3</wagon.http.retryHandler.count>
+        <wagon.http.connectTimeout>5000</wagon.http.connectTimeout>
+      </properties>
+      <repositories>
+        <repository>
+          <id>local-repo</id>
+          <url>file://${user.home}/.m2/repository</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local-repo</id>
+          <url>file://${user.home}/.m2/repository</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
 </settings>

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,6 +15,6 @@ RUN ./mvnw -B -V -e clean package -DskipFrontend=true -Dmaven.test.skip=true -Pc
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app
-COPY --from=build /app/target/backend-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=build /app/target/backend-0.0.1.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/apps/api/pom.xml
+++ b/apps/api/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.trader</groupId>
     <artifactId>backend</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.1</version>
     <name>backend</name>
 
     <properties>

--- a/apps/api/src/main/java/com/trader/backend/controller/OpsController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/OpsController.java
@@ -82,11 +82,11 @@ public class OpsController {
     @GetMapping("/ops/upstox-balance")
     public Mono<ResponseEntity<Map<String, Object>>> upstoxBalance() {
         return upstoxAuthService.fetchBalance()
-                .map(bal -> ResponseEntity.ok(Map.of("balance", bal)))
+                .map(bal -> ResponseEntity.ok(Map.<String, Object>of("balance", bal)))
                 .onErrorResume(ResponseStatusException.class, e -> {
                     if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
                         return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                                .body(Map.of("error", "unauthorized")));
+                                .body(Map.<String, Object>of("error", "unauthorized")));
                     }
                     return Mono.error(e);
                 });

--- a/scripts/prime-m2.sh
+++ b/scripts/prime-m2.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prime the Maven local repository with all dependencies for offline builds.
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+PROJECT_ROOT="$SCRIPT_DIR/../apps/api"
+
+cd "$PROJECT_ROOT"
+echo "Priming Maven cache..."
+./mvnw -B -DskipTests dependency:go-offline
+echo "Resolved dependencies:"
+./mvnw -B -DskipTests -Poffline-ready help:evaluate -Dexpression=project.dependencies | tail -n 20


### PR DESCRIPTION
## Summary
- pin project version and jar naming to release 0.0.1
- add Maven settings with central mirror and offline-ready profile pointing at local cache
- document cache priming and offline build steps
- add two-stage GitHub Actions workflow (prime cache then offline build, run and curl)
- include helper script to prime Maven cache

## Testing
- `bash scripts/prime-m2.sh` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `curl -i http://localhost:8080/ops/upstox-balance` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f5c75cb0832fb1f0dbe10643bbf4