### PR TITLE
Harden Maven network settings

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -3,3 +3,4 @@
 -Dhttp.proxyPort=8080
 -Dhttps.proxyHost=proxy
 -Dhttps.proxyPort=8080
+-Djava.net.preferIPv4Stack=true

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -3,20 +3,36 @@
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <localRepository>${user.home}/.m2/repository</localRepository>
   <mirrors>
+    <!-- Primary official central -->
     <mirror>
-      <id>repo1</id>
-      <name>Maven Central Mirror</name>
-      <url>https://repo1.maven.org/maven2</url>
+      <id>central-primary</id>
+      <name>Maven Central primary</name>
+      <url>https://repo.maven.apache.org/maven2/</url>
       <mirrorOf>central</mirrorOf>
     </mirror>
-    <!-- Optional private mirror; set PRIVATE_MAVEN_MIRROR to enable -->
+    <!-- Fallback Google mirror of Central -->
     <mirror>
-      <id>private</id>
-      <url>${env.PRIVATE_MAVEN_MIRROR}</url>
+      <id>central-google</id>
+      <name>Google mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
       <mirrorOf>central</mirrorOf>
     </mirror>
   </mirrors>
   <profiles>
+    <profile>
+      <id>ci-network</id>
+      <properties>
+        <maven.wagon.http.connectionTimeout>30000</maven.wagon.http.connectionTimeout>
+        <maven.wagon.http.readTimeout>90000</maven.wagon.http.readTimeout>
+        <maven.wagon.http.retryHandler.class>default</maven.wagon.http.retryHandler.class>
+        <maven.wagon.http.retryHandler.count>8</maven.wagon.http.retryHandler.count>
+        <org.eclipse.aether.connector.basic.retryHandler.maxRetries>8</org.eclipse.aether.connector.basic.retryHandler.maxRetries>
+        <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+      </properties>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+    </profile>
     <profile>
       <id>offline-ready</id>
       <properties>
@@ -50,3 +66,4 @@
     </profile>
   </profiles>
 </settings>
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Monorepo
+
+## Building on Railway
+
+Run the backend build with the Maven wrapper using the hardened settings:
+
+```
+./mvnw -B -s .mvn/settings.xml -f apps/api/pom.xml clean package
+```
+
+If tests are flaky you can skip them:
+
+```
+./mvnw -B -s .mvn/settings.xml -f apps/api/pom.xml -DskipTests package
+```

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -6,10 +6,7 @@ COPY .mvn/ .mvn/
 COPY mvnw pom.xml ./
 RUN chmod +x mvnw
 
-# Pre-fetch deps (faster, fewer network surprises)
-RUN ./mvnw -B -V -e -DskipFrontend=true -Dmaven.test.skip=true dependency:go-offline
-
-# Now copy sources and build
+# Copy sources and build
 COPY src ./src
 RUN ./mvnw -B -V -e clean package -DskipFrontend=true -Dmaven.test.skip=true -Pci
 

--- a/scripts/prime-m2.sh
+++ b/scripts/prime-m2.sh
@@ -8,7 +8,6 @@ PROJECT_ROOT="$SCRIPT_DIR/.."
 cd "$PROJECT_ROOT"
 echo "Priming Maven cache..."
 ./mvnw -q -f apps/api/pom.xml help:effective-settings | sed -n '/<localRepository>/,/<\/localRepository>/p'
-./mvnw -B -DskipTests -Poffline-ready -f apps/api/pom.xml -pl :backend -am dependency:go-offline
 ./mvnw -B -DskipTests -Poffline-ready -f apps/api/pom.xml -pl :backend -am package
 echo "Verifying required artifacts..."
 ls -la "$HOME/.m2/repository/io/netty/netty-common/4.1.109.Final/"


### PR DESCRIPTION
## Summary
- Add resilient Maven Central and Google mirrors with aggressive retry/timeout profile
- Prefer IPv4 stack via JVM config
- Drop dependency:go-offline steps from Docker and priming script
- Document Railway build commands using the new settings

## Testing
- `./mvnw -B -s .mvn/settings.xml -f apps/api/pom.xml -DskipTests package` *(failed: Network is unreachable)*
- `java -jar apps/api/target/backend-0.0.1.jar` *(failed: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b69be34b90832f924e355431e573e1