### PR TITLE
feat: add Upstox V3 feed client

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/controller/WsController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/WsController.java
@@ -1,33 +1,31 @@
 package com.trader.backend.controller;
 
-import com.trader.backend.service.LiveFeedService;
 import com.trader.backend.service.Tick;
+import com.trader.backend.service.UpstoxFeedV3Client;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 public class WsController {
-    private final LiveFeedService live;
+    private final UpstoxFeedV3Client feed;
 
     @GetMapping("/ws/status")
     public Map<String, Object> status() {
         Map<String, Object> m = new LinkedHashMap<>();
-        m.put("connected", live.isWsConnected());
-        m.put("lastError", live.lastError());
-        Instant ts = live.lastConnectTs();
-        m.put("lastConnectTs", ts != null ? ts.toString() : null);
-        m.put("lastCloseReason", live.lastCloseReason());
+        m.put("connected", feed.isConnected());
+        m.put("mode", feed.mode());
+        m.put("symbols", feed.symbols());
+        m.put("lastError", feed.lastError());
         return m;
     }
 
     @GetMapping("/ticks/latest")
     public Map<String, Tick> latest() {
-        return live.latestTicks();
+        return feed.latestTicks();
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxFeedV3Client.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxFeedV3Client.java
@@ -1,0 +1,184 @@
+package com.trader.backend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.trader.backend.service.Tick;
+import com.upstox.marketdatafeederv3udapi.rpc.proto.MarketDataFeed;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import org.springframework.core.io.buffer.DataBuffer;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.PostConstruct;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UpstoxFeedV3Client {
+
+    private final UpstoxAuthService auth;
+
+    @Value("${FEED_V3_MODE:ltpc}")
+    private String mode;
+
+    @Value("${TICK_SYMBOLS:}")
+    private String symbolsCsv;
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final AtomicBoolean connected = new AtomicBoolean(false);
+    private final AtomicReference<String> lastError = new AtomicReference<>(null);
+    private final Map<String, Tick> latest = new ConcurrentHashMap<>();
+    private List<String> symbols = new ArrayList<>();
+
+    @PostConstruct
+    void start() {
+        if (symbolsCsv != null && !symbolsCsv.isBlank()) {
+            for (String s : symbolsCsv.split(",")) {
+                String t = s.trim();
+                if (!t.isEmpty()) {
+                    symbols.add(t);
+                }
+            }
+        }
+        if (!symbols.isEmpty()) {
+            connectLoop();
+        } else {
+            log.warn("No TICK_SYMBOLS configured; Upstox feed will not start");
+        }
+    }
+
+    public boolean isConnected() { return connected.get(); }
+    public String mode() { return mode; }
+    public List<String> symbols() { return Collections.unmodifiableList(symbols); }
+    public String lastError() { return lastError.get(); }
+    public Map<String, Tick> latestTicks() { return new LinkedHashMap<>(latest); }
+
+    private void connectLoop() {
+        authorizeAndConnect()
+                .doOnError(e -> {
+                    lastError.set(e.getMessage());
+                    log.warn("WS error: {}", e.toString());
+                })
+                .doFinally(sig -> Mono.delay(Duration.ofSeconds(1)).subscribe(v -> connectLoop()))
+                .subscribe();
+    }
+
+    private Mono<Void> authorizeAndConnect() {
+        String token = auth.currentToken();
+        if (token == null || token.isBlank()) {
+            return Mono.error(new IllegalStateException("Upstox token not available"));
+        }
+        WebClient client = WebClient.builder()
+                .baseUrl("https://api-v2.upstox.com")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+        return client.get()
+                .uri("/feed/market-data-feed/authorize-v3")
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(resp -> {
+                    JsonNode n = resp.path("data").path("authorized_redirect_uri");
+                    if (n.isMissingNode()) {
+                        n = resp.path("authorized_redirect_uri");
+                    }
+                    return n.asText();
+                })
+                .flatMap(this::openWebSocket);
+    }
+
+    private Mono<Void> openWebSocket(String wsUrl) {
+        byte[] frame = buildSubFrame();
+        ReactorNettyWebSocketClient client = new ReactorNettyWebSocketClient();
+        return client.execute(URI.create(wsUrl), session ->
+                session.send(Mono.just(session.binaryMessage(bb -> bb.wrap(frame))))
+                        .thenMany(session.receive()
+                                .map(WebSocketMessage::getPayload)
+                                .doOnSubscribe(s -> {
+                                    connected.set(true);
+                                    lastError.set(null);
+                                    log.info("[ws] v3 authorized and connected");
+                                })
+                                .doOnNext(this::handlePayload)
+                                .then())
+                        .doFinally(sig -> session.closeStatus().doOnNext(cs -> {
+                            connected.set(false);
+                            log.info("[ws] closed code={} reason={}", cs.getCode(), cs.getReason());
+                        }).subscribe())
+        );
+    }
+
+    private byte[] buildSubFrame() {
+        ObjectNode frame = om.createObjectNode();
+        frame.put("guid", UUID.randomUUID().toString());
+        frame.put("method", "sub");
+        ObjectNode data = frame.putObject("data");
+        data.put("mode", mode);
+        ArrayNode arr = data.putArray("instrumentKeys");
+        for (String s : symbols) {
+            arr.add(s);
+        }
+        return frame.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private void handlePayload(DataBuffer buf) {
+        try {
+            byte[] b = new byte[buf.readableByteCount()];
+            buf.read(b);
+            MarketDataFeed.FeedResponse resp = MarketDataFeed.FeedResponse.parseFrom(b);
+            if (resp.getType() == MarketDataFeed.Type.market_info) {
+                log.info("market_info: {}", resp.getMarketInfo().getSegmentStatusMap());
+                return;
+            }
+            resp.getFeedsMap().forEach((key, feed) -> {
+                double price = 0;
+                long ts = 0;
+                if (feed.hasLtpc()) {
+                    price = feed.getLtpc().getLtp();
+                    ts = feed.getLtpc().getLtt();
+                } else if (feed.hasFullFeed()) {
+                    MarketDataFeed.FullFeed ff = feed.getFullFeed();
+                    if (ff.hasMarketFF()) {
+                        MarketDataFeed.MarketFullFeed mf = ff.getMarketFF();
+                        price = mf.getLtpc().getLtp();
+                        ts = mf.getLtpc().getLtt();
+                    } else if (ff.hasIndexFF()) {
+                        MarketDataFeed.IndexFullFeed idx = ff.getIndexFF();
+                        price = idx.getLtpc().getLtp();
+                        ts = idx.getLtpc().getLtt();
+                    }
+                } else if (feed.hasFirstLevelWithGreeks()) {
+                    price = feed.getFirstLevelWithGreeks().getLtpc().getLtp();
+                    ts = feed.getFirstLevelWithGreeks().getLtpc().getLtt();
+                }
+                Instant tsInstant = Instant.ofEpochMilli(ts);
+                latest.put(key, new Tick(key, price, tsInstant));
+                log.info("[tick] {} ltp={} ts={}", key, price, tsInstant);
+            });
+        } catch (Exception e) {
+            log.error("Failed to parse feed", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `UpstoxFeedV3Client` to consume Upstox Market Data Feed V3 via authorize-v3
- expose connection status and latest ticks through existing endpoints

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.trader:backend:0.0.1: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to repo1 (https://repo1.maven.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*
- `curl -i https://api-v2.upstox.com/feed/market-data-feed/authorize-v3 -H "Authorization: Bearer dummy" -H "Accept: application/json"` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b69f5e1e84832f9bb548b241d85c82