### PR TITLE
feat: add robust upstox logging and cors check endpoint

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package com.trader.backend.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,12 +8,17 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
+    @Value("${CORS_ORIGINS:*}")
+    private String origins;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        String[] allowed = origins.split(",");
         registry.addMapping("/**")
-            .allowedOriginPatterns("*")
+            .allowedOriginPatterns(allowed)
             .allowedMethods("*")
             .allowedHeaders("*")
+            .exposedHeaders("X-CORS-Check")
             .allowCredentials(true);
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/config/GlobalErrorHandler.java
+++ b/apps/api/src/main/java/com/trader/backend/config/GlobalErrorHandler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @ControllerAdvice
 @Slf4j
@@ -12,7 +13,17 @@ public class GlobalErrorHandler {
 
     @ExceptionHandler(Throwable.class)
     public ResponseEntity<String> handleException(Throwable ex) {
-        log.error("Unhandled exception", ex);
+        if (ex instanceof WebClientResponseException w) {
+            String body = w.getResponseBodyAsString();
+            if (body == null) body = "";
+            body = body.replaceAll("\n", " ");
+            if (body.length() > 300) body = body.substring(0,300) + "...";
+            String method = w.getRequest() != null && w.getRequest().method() != null ? w.getRequest().method().name() : "";
+            String url = w.getRequest() != null ? w.getRequest().url().toString() : "";
+            log.error("Unhandled exception HTTP {} {} {} body={}", w.getStatusCode().value(), method, url, body, w);
+        } else {
+            log.error("Unhandled exception", ex);
+        }
         return new ResponseEntity<>("Server Error: " + ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/controller/StatusController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/StatusController.java
@@ -2,6 +2,7 @@ package com.trader.backend.controller;
 
 import com.trader.backend.service.MarketStatusService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,5 +14,10 @@ public class StatusController {
     @GetMapping("/status/market")
     public MarketStatusService.Status market() {
         return marketStatusService.getStatus();
+    }
+
+    @GetMapping("/status/cors-check")
+    public ResponseEntity<Void> corsCheck() {
+        return ResponseEntity.ok().header("X-CORS-Check", "ok").build();
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/service/HistoricalCandleScheduler.java
+++ b/apps/api/src/main/java/com/trader/backend/service/HistoricalCandleScheduler.java
@@ -1,0 +1,90 @@
+package com.trader.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import javax.annotation.PostConstruct;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeoutException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HistoricalCandleScheduler {
+
+    private final MarketDataService marketDataService;
+
+    @Value("${HC_SCHED_KEYS:}")
+    private String keysCsv;
+
+    private final Map<String, Instant> nextAllowed = new ConcurrentHashMap<>();
+    private final Map<String, Instant> pauseUntil = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    void init() {
+        if (keysCsv == null || keysCsv.isBlank()) {
+            log.info("[hist] HC_SCHED_KEYS not set; scheduler disabled");
+            return;
+        }
+        for (String s : keysCsv.split(",")) {
+            String key = s.trim();
+            if (!key.isEmpty()) {
+                schedule(key);
+            }
+        }
+    }
+
+    private void schedule(String key) {
+        Flux.interval(Duration.ZERO, Duration.ofSeconds(5))
+                .flatMap(t -> poll(key))
+                .subscribe();
+    }
+
+    private Mono<Void> poll(String key) {
+        Instant now = Instant.now();
+        Instant pause = pauseUntil.get(key);
+        if (pause != null && now.isBefore(pause)) {
+            return Mono.empty();
+        }
+        Instant next = nextAllowed.getOrDefault(key, Instant.EPOCH);
+        if (now.isBefore(next)) {
+            return Mono.empty();
+        }
+        nextAllowed.put(key, now.plusSeconds(60));
+        log.info("[hist] {} next-at {}", key, nextAllowed.get(key));
+        String today = LocalDate.now().toString();
+        return marketDataService.candleV3(key, "minute", 1, today, null)
+                .retryWhen(Retry.backoff(5, Duration.ofSeconds(5))
+                        .maxBackoff(Duration.ofMinutes(1))
+                        .jitter(0.3)
+                        .filter(HistoricalCandleScheduler::isTransient))
+                .doOnError(ex -> {
+                    if (ex instanceof WebClientResponseException w && w.getStatusCode().is4xxClientError()) {
+                        Instant resume = Instant.now().plus(Duration.ofMinutes(10 + ThreadLocalRandom.current().nextInt(6)));
+                        pauseUntil.put(key, resume);
+                        log.warn("[hist] {} {} -> pause until {}", key, w.getStatusCode().value(), resume);
+                    }
+                })
+                .onErrorResume(ex -> Mono.empty())
+                .then();
+    }
+
+    private static boolean isTransient(Throwable ex) {
+        if (ex instanceof WebClientResponseException w) {
+            int code = w.getStatusCode().value();
+            return code == 429 || w.getStatusCode().is5xxServerError();
+        }
+        return ex instanceof TimeoutException || ex instanceof java.io.IOException;
+    }
+}

--- a/apps/api/src/main/java/com/trader/backend/service/MarketDataService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/MarketDataService.java
@@ -1,8 +1,10 @@
 package com.trader.backend.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -13,6 +15,7 @@ import java.net.URI;
 // (exact same file you created earlier)
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MarketDataService {
 
     private final UpstoxAuthService auth;
@@ -72,6 +75,14 @@ public class MarketDataService {
                 .uri(URI.create(url))     // <<< use URI to STOP extra encoding
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, resp ->
+                        resp.bodyToMono(String.class).defaultIfEmpty("")
+                                .flatMap(body -> {
+                                    log.error("[upstox] {} {} -> HTTP {} body={}",
+                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
+                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    return resp.createException();
+                                }))
                 .bodyToMono(String.class);
     }
 

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -10,6 +10,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -102,6 +103,14 @@ public class UpstoxAuthService {
                         .with("redirect_uri", webhookUri)
                         .with("grant_type", "authorization_code"))
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, resp ->
+                        resp.bodyToMono(String.class).defaultIfEmpty("")
+                                .flatMap(body -> {
+                                    log.error("[upstox] {} {} -> HTTP {} body={}",
+                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
+                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    return resp.createException();
+                                }))
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
                 .doOnNext(tok -> {
                     String at = (String) tok.get("access_token");
@@ -128,7 +137,9 @@ public class UpstoxAuthService {
                     apiClient.addDefaultHeader("Authorization", "Bearer " + at);
                     saveTokenBundle(at, refreshToken.get(), exp);
                     authEvents.tryEmitNext(AuthEvent.READY);
-                    log.info("✅ access_token saved (expires {})", exp > 0 ? Instant.ofEpochSecond(exp) : "unknown");
+                    String scope = (String) tok.get("scope");
+                    log.info("[auth] token acquired exp={} scope={}",
+                            exp > 0 ? Instant.ofEpochSecond(exp) : null, scope);
                 })
                 .then();
     }
@@ -180,6 +191,14 @@ public class UpstoxAuthService {
                         .with("client_id", apiKey)
                         .with("client_secret", apiSecret))
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, resp ->
+                        resp.bodyToMono(String.class).defaultIfEmpty("")
+                                .flatMap(body -> {
+                                    log.error("[upstox] {} {} -> HTTP {} body={}",
+                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
+                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    return resp.createException();
+                                }))
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
                 .map(tok -> {
                     String at = (String) tok.get("access_token");
@@ -194,7 +213,8 @@ public class UpstoxAuthService {
                     expiresAt.set(exp);
                     apiClient.addDefaultHeader("Authorization", "Bearer " + at);
                     saveTokenBundle(at, refreshToken.get(), exp);
-                    log.info("🔄 Refreshed access_token ({} sec left)", ttl);
+                    String scope = (String) tok.get("scope");
+                    log.info("[auth] token acquired exp={} scope={}", Instant.ofEpochSecond(exp), scope);
                     authEvents.tryEmitNext(AuthEvent.READY);
                     return true;
                 })
@@ -283,6 +303,14 @@ public class UpstoxAuthService {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, resp ->
+                        resp.bodyToMono(String.class).defaultIfEmpty("")
+                                .flatMap(body -> {
+                                    log.error("[upstox] {} {} -> HTTP {} body={}",
+                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
+                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    return resp.createException();
+                                }))
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
                 .map(resp -> {
                     @SuppressWarnings("unchecked")
@@ -306,11 +334,17 @@ public class UpstoxAuthService {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .retrieve()
-                .onStatus(status -> status.value() == 401,
-                        resp -> {
-                            log.warn("Upstox API responded 401 for balance fetch");
-                            return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
-                        })
+                .onStatus(HttpStatusCode::isError, resp ->
+                        resp.bodyToMono(String.class).defaultIfEmpty("")
+                                .flatMap(body -> {
+                                    log.error("[upstox] {} {} -> HTTP {} body={}",
+                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
+                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    if (resp.statusCode().value() == 401) {
+                                        return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
+                                    }
+                                    return resp.createException();
+                                }))
                 .bodyToMono(JsonNode.class)
                 .map(j -> j.at("/data/equity/available_margin").asDouble(0.0));
     }

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxFeedV3Client.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxFeedV3Client.java
@@ -14,6 +14,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.socket.WebSocketMessage;
@@ -122,6 +123,14 @@ public class UpstoxFeedV3Client {
         return client.get()
                 .uri("/feed/market-data-feed/authorize-v3")
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, resp ->
+                        resp.bodyToMono(String.class).defaultIfEmpty("")
+                                .flatMap(body -> {
+                                    log.error("[upstox] {} {} -> HTTP {} body={}",
+                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
+                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    return resp.createException();
+                                }))
                 .bodyToMono(JsonNode.class)
                 .map(resp -> {
                     JsonNode n = resp.path("data").path("authorized_redirect_uri");
@@ -130,6 +139,7 @@ public class UpstoxFeedV3Client {
                     }
                     return n.asText();
                 })
+                .doOnNext(v -> log.info("[ws] authorize-v3 ok; redirect_uri=present"))
                 .flatMap(this::openWebSocket);
     }
 


### PR DESCRIPTION
## Summary
- log upstream HTTP errors and response snippets for all Upstox WebClient calls
- expose `/status/cors-check` and tighten CORS config with custom header
- add historical candle scheduler with retry/backoff and pause on 4xx

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68b7de99aa54832f8d6934d98fc07ef1