### PR TITLE
Fix build: replace invalid request logging (method()/url()) with proper WebClient filters; remove ClientResponse.request() usage; keep JSON WS subscribe.

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/service/MarketDataService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/MarketDataService.java
@@ -78,9 +78,8 @@ public class MarketDataService {
                 .onStatus(HttpStatusCode::isError, resp ->
                         resp.bodyToMono(String.class).defaultIfEmpty("")
                                 .flatMap(body -> {
-                                    log.error("[upstox] {} {} -> HTTP {} body={}",
-                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
-                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    String b = body.length() > 500 ? body.substring(0,500) + "..." : body;
+                                    log.error("[upstox] HTTP {} body={}", resp.statusCode().value(), b);
                                     return resp.createException();
                                 }))
                 .bodyToMono(String.class);

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Flux;
@@ -42,7 +43,12 @@ import java.util.concurrent.atomic.AtomicReference;
 @Slf4j
 public class UpstoxAuthService {
 
-    private final WebClient webClient = WebClient.create("https://api.upstox.com/v2");
+    private final WebClient webClient = WebClient.builder()
+            .baseUrl("https://api.upstox.com/v2")
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .filter(logRequest())
+            .filter(logResponse())
+            .build();
     private final ObjectMapper mapper = new ObjectMapper();
     private final ApiClient apiClient;
     private final LiveFeedService liveFeed;
@@ -106,9 +112,8 @@ public class UpstoxAuthService {
                 .onStatus(HttpStatusCode::isError, resp ->
                         resp.bodyToMono(String.class).defaultIfEmpty("")
                                 .flatMap(body -> {
-                                    log.error("[upstox] {} {} -> HTTP {} body={}",
-                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
-                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    String b = body.length() > 500 ? body.substring(0,500) + "..." : body;
+                                    log.error("[upstox] HTTP {} body={}", resp.statusCode().value(), b);
                                     return resp.createException();
                                 }))
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
@@ -194,9 +199,8 @@ public class UpstoxAuthService {
                 .onStatus(HttpStatusCode::isError, resp ->
                         resp.bodyToMono(String.class).defaultIfEmpty("")
                                 .flatMap(body -> {
-                                    log.error("[upstox] {} {} -> HTTP {} body={}",
-                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
-                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    String b = body.length() > 500 ? body.substring(0,500) + "..." : body;
+                                    log.error("[upstox] HTTP {} body={}", resp.statusCode().value(), b);
                                     return resp.createException();
                                 }))
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
@@ -306,9 +310,8 @@ public class UpstoxAuthService {
                 .onStatus(HttpStatusCode::isError, resp ->
                         resp.bodyToMono(String.class).defaultIfEmpty("")
                                 .flatMap(body -> {
-                                    log.error("[upstox] {} {} -> HTTP {} body={}",
-                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
-                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    String b = body.length() > 500 ? body.substring(0,500) + "..." : body;
+                                    log.error("[upstox] HTTP {} body={}", resp.statusCode().value(), b);
                                     return resp.createException();
                                 }))
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
@@ -337,9 +340,8 @@ public class UpstoxAuthService {
                 .onStatus(HttpStatusCode::isError, resp ->
                         resp.bodyToMono(String.class).defaultIfEmpty("")
                                 .flatMap(body -> {
-                                    log.error("[upstox] {} {} -> HTTP {} body={}",
-                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
-                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    String b = body.length() > 500 ? body.substring(0,500) + "..." : body;
+                                    log.error("[upstox] HTTP {} body={}", resp.statusCode().value(), b);
                                     if (resp.statusCode().value() == 401) {
                                         return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
                                     }
@@ -380,6 +382,20 @@ public class UpstoxAuthService {
                 .queryParam("state", "botInit")
                 .queryParam("scope", "profile marketdata")
                 .build().toUriString();
+    }
+
+    private static ExchangeFilterFunction logRequest() {
+        return ExchangeFilterFunction.ofRequestProcessor(req -> {
+            log.info("[http->] {} {}", req.method(), req.url());
+            return Mono.just(req);
+        });
+    }
+
+    private static ExchangeFilterFunction logResponse() {
+        return ExchangeFilterFunction.ofResponseProcessor(resp -> {
+            log.info("[http<-] status={}", resp.statusCode().value());
+            return Mono.just(resp);
+        });
     }
 
     /** Authentication lifecycle events. */

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxFeedV3Client.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxFeedV3Client.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.socket.WebSocketMessage;
 import org.springframework.web.reactive.socket.WebSocketSession;
@@ -119,6 +120,8 @@ public class UpstoxFeedV3Client {
                 .baseUrl("https://api-v2.upstox.com")
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .filter(logRequest())
+                .filter(logResponse())
                 .build();
         return client.get()
                 .uri("/feed/market-data-feed/authorize-v3")
@@ -126,9 +129,8 @@ public class UpstoxFeedV3Client {
                 .onStatus(HttpStatusCode::isError, resp ->
                         resp.bodyToMono(String.class).defaultIfEmpty("")
                                 .flatMap(body -> {
-                                    log.error("[upstox] {} {} -> HTTP {} body={}",
-                                            resp.request().method(), resp.request().url(), resp.statusCode().value(),
-                                            body.length() > 500 ? body.substring(0,500) + "..." : body);
+                                    String b = body.length() > 500 ? body.substring(0,500) + "..." : body;
+                                    log.error("[upstox] HTTP {} body={}", resp.statusCode().value(), b);
                                     return resp.createException();
                                 }))
                 .bodyToMono(JsonNode.class)
@@ -228,5 +230,19 @@ public class UpstoxFeedV3Client {
         } finally {
             DataBufferUtils.release(buf);
         }
+    }
+
+    private static ExchangeFilterFunction logRequest() {
+        return ExchangeFilterFunction.ofRequestProcessor(req -> {
+            log.info("[http->] {} {}", req.method(), req.url());
+            return Mono.just(req);
+        });
+    }
+
+    private static ExchangeFilterFunction logResponse() {
+        return ExchangeFilterFunction.ofResponseProcessor(resp -> {
+            log.info("[http<-] status={}", resp.statusCode().value());
+            return Mono.just(resp);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- add reusable WebClient request/response logging filters
- drop ClientResponse.request() logging and log only status+body
- keep Upstox v3 WS JSON subscribe frame and Mono-based receiver

## Testing
- `mvn -B -DskipTests package` *(fails: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e8506924832f97985583109b1401