### PR TITLE
Add auth gating and health endpoint

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/controller/HealthController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/HealthController.java
@@ -1,0 +1,27 @@
+package com.trader.backend.controller;
+
+import com.trader.backend.service.UpstoxAuthService;
+import com.trader.backend.service.UpstoxFeedV3Client;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class HealthController {
+    private final UpstoxAuthService auth;
+    private final UpstoxFeedV3Client feed;
+
+    @GetMapping("/status/health")
+    public Map<String, Object> health() {
+        Map<String, Object> m = new HashMap<>();
+        m.put("state", auth.state().name());
+        m.put("hasToken", auth.currentToken() != null);
+        m.put("wsConnected", feed.isConnected());
+        m.put("symbols", feed.symbols().size());
+        return m;
+    }
+}

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -69,6 +69,8 @@ public class UpstoxAuthService {
     private final Path tokenFile = Paths.get("token.json");
 
     private final Sinks.Many<AuthEvent> authEvents = Sinks.many().replay().latest();
+    public enum State { BOOT, WAIT_AUTH, AUTH_READY, WS_CONNECTING, WS_LIVE, INSTR_DISCOVERY, LTP_FLOW, OPTIONS_LIVE }
+    private final AtomicReference<State> state = new AtomicReference<>(State.WAIT_AUTH);
 
     public UpstoxAuthService(ApiClient apiClient, @Lazy LiveFeedService liveFeed) {
         this.apiClient = apiClient;
@@ -83,6 +85,7 @@ public class UpstoxAuthService {
     void init() {
         log.info("No Upstox token yet — waiting for OAuth login (GET /auth/url).");
         authEvents.tryEmitNext(AuthEvent.WAITING);
+        state.set(State.WAIT_AUTH);
     }
 
     /** Event stream for authentication state changes. */
@@ -142,6 +145,7 @@ public class UpstoxAuthService {
                     apiClient.addDefaultHeader("Authorization", "Bearer " + at);
                     saveTokenBundle(at, refreshToken.get(), exp);
                     authEvents.tryEmitNext(AuthEvent.READY);
+                    state.set(State.AUTH_READY);
                     String scope = (String) tok.get("scope");
                     log.info("[auth] token acquired exp={} scope={}",
                             exp > 0 ? Instant.ofEpochSecond(exp) : null, scope);
@@ -220,6 +224,7 @@ public class UpstoxAuthService {
                     String scope = (String) tok.get("scope");
                     log.info("[auth] token acquired exp={} scope={}", Instant.ofEpochSecond(exp), scope);
                     authEvents.tryEmitNext(AuthEvent.READY);
+                    state.set(State.AUTH_READY);
                     return true;
                 })
                 .onErrorResume(e -> {
@@ -254,6 +259,9 @@ public class UpstoxAuthService {
         accessToken.set(token);
         apiClient.addDefaultHeader("Authorization", "Bearer " + token);
     }
+
+    public State state() { return state.get(); }
+    public void setState(State s) { state.set(s); }
 
     /**
      * Simple status endpoint helper.

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxFeedV3Client.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxFeedV3Client.java
@@ -102,6 +102,12 @@ public class UpstoxFeedV3Client {
     }
 
     private void connectLoop() {
+        String token = auth.currentToken();
+        if (token == null || token.isBlank()) {
+            Mono.delay(Duration.ofSeconds(1)).subscribe(v -> connectLoop());
+            return;
+        }
+        auth.setState(UpstoxAuthService.State.WS_CONNECTING);
         authorizeAndConnect()
                 .doOnError(e -> {
                     lastError.set(e.getMessage());
@@ -141,7 +147,7 @@ public class UpstoxFeedV3Client {
                     }
                     return n.asText();
                 })
-                .doOnNext(v -> log.info("[ws] authorize-v3 ok; redirect_uri=present"))
+                .doOnNext(v -> log.info("[ws] authorize-v3 ok"))
                 .flatMap(this::openWebSocket);
     }
 
@@ -160,6 +166,7 @@ public class UpstoxFeedV3Client {
                         connected.set(true);
                         lastError.set(null);
                         marketStatusService.setWsConnected(true);
+                        auth.setState(UpstoxAuthService.State.WS_LIVE);
                         log.info("[ws] v3 authorized and connected");
                     })
                     .map(WebSocketMessage::getPayload)


### PR DESCRIPTION
## Summary
- track auth & websocket state in `UpstoxAuthService`
- wait for token before connecting websocket and log authorized connection
- expose `/status/health` for lightweight monitoring

## Testing
- `./mvnw -q -o -Poffline-ready -f apps/api/pom.xml -pl :backend -am package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f1052cd8832fa5059b83fa947366