### PR TITLE
feat: orchestrate market startup and logging

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
-    @Value("${CORS_ORIGINS:*}")
+    @Value("${APP_CORS_ALLOWED_ORIGINS:*}")
     private String origins;
 
     @Override
@@ -16,9 +16,8 @@ public class CorsConfig implements WebMvcConfigurer {
         String[] allowed = origins.split(",");
         registry.addMapping("/**")
             .allowedOriginPatterns(allowed)
-            .allowedMethods("*")
-            .allowedHeaders("*")
-            .exposedHeaders("X-CORS-Check")
+            .allowedMethods("GET", "POST", "OPTIONS")
+            .allowedHeaders("Authorization", "Content-Type")
             .allowCredentials(true);
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/config/InfluxConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/InfluxConfig.java
@@ -12,23 +12,23 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class InfluxConfig {
 
-    @Value("${influx.url:}")
+    @Value("${INFLUX_URL:}")
     private String url;
 
-    @Value("${influx.token:}")
+    @Value("${INFLUX_TOKEN:}")
     private String token;
 
-    @Value("${influx.org:}")
+    @Value("${INFLUX_ORG:}")
     private String org;
 
-    @Value("${influx.bucket:}")
+    @Value("${INFLUX_BUCKET:}")
     private String bucket;
 
     /**
      * Create a singleton InfluxDBClient that knows your URL, token, org & bucket.
      */
     @Bean
-    @ConditionalOnProperty(prefix = "influx", name = "url")
+    @ConditionalOnProperty(name = "INFLUX_URL")
     public InfluxDBClient influxDBClient() {
         // note: token must be passed as char[] for security
         return InfluxDBClientFactory.create(url, token.toCharArray(), org, bucket);

--- a/apps/api/src/main/java/com/trader/backend/config/StartupConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/StartupConfig.java
@@ -1,0 +1,69 @@
+package com.trader.backend.config;
+
+import com.trader.backend.service.UpstoxAuthService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class StartupConfig {
+
+    private final UpstoxAuthService auth;
+
+    @Value("${UPSTOX_WEBHOOK_URI:}")
+    private String webhookUri;
+
+    @Value("${SPRING_DATA_MONGODB_URI:}")
+    private String mongoUri;
+
+    @Value("${INFLUX_URL:}")
+    private String influxUrl;
+
+    @Value("${INFLUX_TOKEN:}")
+    private String influxToken;
+
+    @Value("${INFLUX_ORG:}")
+    private String influxOrg;
+
+    @Value("${INFLUX_BUCKET:}")
+    private String influxBucket;
+
+    @Value("${APP_CORS_ALLOWED_ORIGINS:}")
+    private String corsOrigins;
+
+    @Value("${APP_MOCK:false}")
+    private boolean mock;
+
+    @PostConstruct
+    public void boot() {
+        String mongoPresence = (mongoUri != null && !mongoUri.isBlank()) ? "present" : "absent";
+        log.info("BOOT Config: webhookUri={} mongodb.uri={} influx.org={} bucket={} cors.origins={} mock={}",
+                webhookUri,
+                mongoPresence,
+                influxOrg,
+                influxBucket,
+                corsOrigins,
+                mock);
+
+        if (System.getenv("UPSTOX_API_KEY") == null || System.getenv("UPSTOX_API_SECRET") == null || webhookUri == null || webhookUri.isBlank()) {
+            log.error("Missing Upstox credentials");
+            System.exit(0);
+        }
+        if (mongoUri == null || mongoUri.isBlank()) {
+            log.error("Missing MongoDB URI");
+            System.exit(0);
+        }
+        boolean influxOk = influxUrl != null && !influxUrl.isBlank()
+                && influxToken != null && !influxToken.isBlank()
+                && influxOrg != null && !influxOrg.isBlank()
+                && influxBucket != null && !influxBucket.isBlank();
+        if (!influxOk) {
+            log.warn("Influx disabled: writing skipped");
+        }
+        auth.init();
+    }
+}

--- a/apps/api/src/main/java/com/trader/backend/controller/SignalController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/SignalController.java
@@ -1,35 +1,61 @@
 package com.trader.backend.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.trader.backend.events.SignalEvent;
-import com.trader.backend.service.SignalEngine;
+import com.trader.backend.service.LiveFeedService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 
-/**
- * Server Sent Events endpoint exposing live trading signals.
- */
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 public class SignalController {
 
-    private final SignalEngine engine;
+    private final LiveFeedService live;
     private final ObjectMapper mapper = new ObjectMapper();
 
     @GetMapping(value = "/signals/live", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> live() {
-        return engine.stream().map(this::toJson);
+        return Flux.interval(Duration.ofSeconds(1))
+                .map(i -> {
+                    try {
+                        return mapper.writeValueAsString(buildPayload());
+                    } catch (Exception e) {
+                        return "{}";
+                    }
+                });
     }
 
-    private String toJson(SignalEvent ev) {
-        try {
-            return mapper.writeValueAsString(ev);
-        } catch (JsonProcessingException e) {
-            return "{}";
+    private Map<String, Object> buildPayload() {
+        Map<String, Object> root = new LinkedHashMap<>();
+        Map<String, Object> status = new LinkedHashMap<>();
+        status.put("connected", live.isWsConnected());
+        status.put("marketOpen", live.isMarketOpen());
+        Instant lt = live.lastTickTs();
+        status.put("lastTickTs", lt != null ? lt.toString() : null);
+        root.put("status", status);
+
+        String futKey = live.currentFutKey();
+        Map<String, Object> fut = new LinkedHashMap<>();
+        if (futKey != null) {
+            fut.put("key", futKey);
+            fut.put("ltp", live.getLatestLtp(futKey));
         }
+        root.put("fut", fut.isEmpty() ? null : fut);
+
+        Map<String, Double> opts = new LinkedHashMap<>();
+        live.latestTicks().forEach((k, v) -> {
+            if (!k.equals(futKey)) {
+                opts.put(k, v.ltp());
+            }
+        });
+        root.put("opts", opts);
+        return root;
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -84,7 +84,7 @@ public class LiveFeedService {
     private final QuantAnalysisService quantAnalysisService;
     private final MarketState marketState;
     private final DepthMetricsService depthMetricsService;
-    @Value("${app.mock:false}")
+    @Value("${APP_MOCK:false}")
     private boolean mockMode;
 private final Sinks.Many<JsonNode> sink = Sinks.many().multicast().onBackpressureBuffer();
 private final AtomicBoolean optionsStreamStarted = new AtomicBoolean(false);
@@ -95,6 +95,8 @@ private final AtomicBoolean optionsStreamStarted = new AtomicBoolean(false);
     private final AtomicInteger optSubscribedCount = new AtomicInteger(0);
     private final AtomicLong ticksLast60s = new AtomicLong();
     private final AtomicReference<Instant> lastTickTs = new AtomicReference<>(null);
+    private final AtomicReference<String> currentFutKey = new AtomicReference<>(null);
+    private final AtomicBoolean futLtpLogged = new AtomicBoolean(false);
 
 private final AtomicLong lastAutoStartLog = new AtomicLong(0);
 
@@ -147,13 +149,14 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
     public Instant lastConnectTs() { return lastConnectTs.get(); }
     public String lastCloseReason() { return lastCloseReason.get(); }
     public Map<String, Tick> latestTicks() { return new LinkedHashMap<>(lastTick); }
+    public String currentFutKey() { return currentFutKey.get(); }
 
     private final Sinks.Many<LtpEvent> ltpSink = Sinks.many().multicast().onBackpressureBuffer();
     public Flux<LtpEvent> ltpEvents() { return ltpSink.asFlux(); }
 
-    @Value("${influx.bucket:}")
+    @Value("${INFLUX_BUCKET:}")
     private String influxBucket;
-    @Value("${influx.org:}")
+    @Value("${INFLUX_ORG:}")
     private String influxOrg;
 
     private final Map<String, NseInstrument> instrumentCache = new ConcurrentHashMap<>();
@@ -199,16 +202,11 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
     public void subscribeToAuthEvents() {
         auth.events()
                 .filter(e -> e == UpstoxAuthService.AuthEvent.READY)
-                .subscribe(ev -> {
-                    nseInstrumentService.refreshIfOptionsEmpty();
-                    ensureOptionStream();
-                    connectIfOpenOrSchedule();
-                });
+                .subscribe(ev -> startOrchestration());
 
         auth.events()
                 .filter(e -> e == UpstoxAuthService.AuthEvent.EXPIRED)
                 .subscribe(e -> {
-                    log.warn("Auth token expired or refresh failed; waiting for re-login");
                     orchestratorState.set(OrchestratorState.IDLE);
                     selectionComputed.set(false);
                 });
@@ -226,47 +224,45 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
                     long opt = optWrites.getAndSet(0);
                     ticksLast60s.set(fut + opt);
                     String source = connected.get() ? "live" : "influx";
-                    log.info("HEARTBEAT market={} liveFut={} liveOpts={} writesFut={}/15s writesOpt={}/15s sourceUsed={} ceLoadedCount={} peLoadedCount={}",
-                            open ? "open" : "closed", futOn ? "on" : "off", optCount, fut, opt, source,
-                            ceLoadedCount.get(), peLoadedCount.get());
+                    log.info("HEARTBEAT market={} liveFut={} liveOpts={} writesFut={}/15s writesOpt={}/15s sourceUsed={}",
+                            open ? "open" : "closed", futOn ? "on" : "off", optCount, fut, opt, source);
                 });
+    }
+
+    private void startOrchestration() {
+        nseInstrumentService.ensureNseJsonLoaded();
+        log.info("FLOW 1/8: NSE JSON loaded (size={})", nseInstrumentService.getCachedNse().size());
+        nseInstrumentService.purgeExpiredOptionDocs();
+        log.info("FLOW 2/8: Purged expired option docs");
+        long count = nseInstrumentService.saveNiftyFuturesToMongo();
+        log.info("FLOW 3/8: NIFTY FUT contracts saved → mongo collection=nifty_futures count={}", count);
+        connectIfOpenOrSchedule();
     }
 
     public void connectIfOpenOrSchedule() {
         Instant now = Instant.now();
-        ZoneId tz = MarketHours.zone();
-        ZonedDateTime nowIst = now.atZone(tz);
-        ZonedDateTime openIst = nowIst.with(MarketHours.openTime()).withSecond(0).withNano(0);
-        ZonedDateTime closeIst = nowIst.with(MarketHours.closeTime()).withSecond(0).withNano(0);
-
         boolean isTradingWindowNow = MarketHours.isOpen(now);
-        boolean todayIsTradingDay = MarketHours.isTradingDay(nowIst.toLocalDate());
-        boolean tokenPresent = auth.currentToken() != null;
-        boolean connected = orchestratorState.get() == OrchestratorState.READY;
-        boolean shouldStart = isTradingWindowNow && todayIsTradingDay && tokenPresent && !connected;
-
-        String decision = shouldStart ? "START" : "WAIT";
-
-        if (shouldStart) {
-            startLive();
-        } else if (!isTradingWindowNow) {
+        boolean todayIsTradingDay = MarketHours.isTradingDay(now.atZone(MarketHours.zone()).toLocalDate());
+        log.info("FLOW 4/8: Market window check → isOpen={} todayTradingDay={}", isTradingWindowNow, todayIsTradingDay);
+        if (!isTradingWindowNow) {
             Instant next = MarketHours.nextOpenAfter(now);
-            log.info("Market closed — scheduling live feed start at {}", next);
+            log.info("FLOW 5/8: Market closed — scheduling live feed at {}", next.atZone(MarketHours.zone()));
             long delay = Duration.between(now, next).toMillis();
             Mono.delay(Duration.ofMillis(delay)).subscribe(v -> startLive());
-        }
-
-        long nowMs = System.currentTimeMillis();
-        long prev = lastAutoStartLog.get();
-        if (nowMs - prev >= 60_000 && lastAutoStartLog.compareAndSet(prev, nowMs)) {
-            log.info("AUTO-START-CHECK nowIst={} openIst={} closeIst={} isTradingWindowNow={} todayIsTradingDay={} tokenPresent={} connected={} decision={}",
-                    nowIst.toLocalTime(), openIst.toLocalTime(), closeIst.toLocalTime(),
-                    isTradingWindowNow, todayIsTradingDay, tokenPresent, connected, decision);
+        } else {
+            log.info("FLOW 5/8: Market open — starting live feed");
+            startLive();
         }
     }
 
     public void startLive() {
-        initLiveWebSocket();
+        if (mockMode) {
+            log.info("🧪 Mock mode enabled - skipping live feed startup");
+            return;
+        }
+        orchestratorState.set(OrchestratorState.RUNNING);
+        streamNiftyFutAndTriggerCEPE();
+        orchestratorState.set(OrchestratorState.READY);
     }
 
     private void ensureOptionStream() {
@@ -302,37 +298,6 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
         ZonedDateTime nowIst = ZonedDateTime.now(MarketHours.zone());
         nseInstrumentService.ensureOptionsLoaded(nowIst);
         startLive();
-    }
-
-    public void initLiveWebSocket() {
-        if (mockMode) {
-            log.info("🧪 Mock mode enabled - skipping live feed startup");
-            return;
-        }
-        Instant now = Instant.now();
-        if (!MarketHours.isOpen(now)) {
-            log.info("Market closed — skipping WS connect until {}", MarketHours.nextOpenAfter(now));
-            return;
-        }
-        if (!orchestratorState.compareAndSet(OrchestratorState.IDLE, OrchestratorState.RUNNING)) {
-            return;
-        }
-        log.info("OAuth success — starting market pipeline...");
-        try {
-            if (instrumentsInitialized.compareAndSet(false, true)) {
-                nseInstrumentService.ensureNseJsonLoaded();
-                nseInstrumentService.purgeExpiredOptionDocs();
-                nseInstrumentService.refreshIfOptionsEmpty();
-                nseInstrumentService.saveNiftyFuturesToMongo();
-            } else {
-                log.info("init sequence skipped: already initialized");
-            }
-            streamNiftyFutAndTriggerCEPE();
-        } catch (Exception e) {
-            log.error("❌ init sequence failed", e);
-        } finally {
-            orchestratorState.set(OrchestratorState.READY);
-        }
     }
 
     /**
@@ -828,20 +793,20 @@ public MongoTemplate getMongoTemplate() {
     return mongoTemplate;
 }
 public void streamNiftyFutAndTriggerCEPE() {
-    log.info("🚀 Subscribing to NIFTY FUT to extract LTP and filter CE/PE...");
-
     if (auth.currentToken() == null) {
         log.warn("⚠️ Cannot start NIFTY FUT stream — token not available");
         return;
     }
 
-    Optional<String> optKey = nseInstrumentService.nearestNiftyFutureKey();
+    Optional<String> optKey = nseInstrumentService.getCurrentMonthNiftyFutKey();
     if (optKey.isEmpty()) {
-        log.error("❌ No valid NIFTY FUT contract to subscribe.");
+        log.error("ERR FUT: current-month NIFTY FUT not found — cannot subscribe");
         return;
     }
     String instrumentKey = optKey.get();
-    log.info("📦 Subscribing to NIFTY FUT: {}", instrumentKey);
+    currentFutKey.set(instrumentKey);
+    futLtpLogged.set(false);
+    selectionComputed.set(false);
 
     fetchWebSocketUrl()
             .flatMapMany(wsUrl -> openWebSocketForOptions(wsUrl, buildSubFrame(instrumentKey)))
@@ -866,19 +831,19 @@ public void streamNiftyFutAndTriggerCEPE() {
                         marketState.setLastTickTs(ts);
                         bufferOptionTick(instrumentKey, feed, ts, ltp);
 
-                        if (selectionComputed.compareAndSet(false, true)) {
-                            nseInstrumentService.filterStrikesAroundLtpFromJson(ltp);
-                            NseInstrumentService.SelectionData sel = nseInstrumentService.currentSelectionData();
-                            String sig = nseInstrumentService.selectionSignature(sel);
+                        if (futLtpLogged.compareAndSet(false, true)) {
+                            log.info("FLOW 6/8: FUT LTP resolved key={} ltp={} ts={}", instrumentKey, ltp, Instant.ofEpochMilli(ts));
+                            NseInstrumentService.OptionBatch batch = nseInstrumentService.filterStrikesAroundLtpFromJson(ltp);
+                            int ce = batch.ce().size();
+                            int pe = batch.pe().size();
+                            String expiry = nseInstrumentService.formatExpiry(batch.expiry());
+                            String sig = expiry + ":" + ce + ":" + pe;
                             if (sig.equals(lastSelectionSignature.get())) {
-                                log.info("Orchestration skipped — selection unchanged (expiry={})", nseInstrumentService.formatExpiry(sel.expiry()));
+                                log.info("FLOW 7/8: Selection unchanged — expiry={} ce={} pe={}", expiry, ce, pe);
                             } else {
                                 lastSelectionSignature.set(sig);
+                                log.info("FLOW 7/8: Options selected from NSE JSON — expiry={} ce={} pe={}", expiry, ce, pe);
                                 streamFilteredNiftyOptions();
-                                log.info("Setup complete — FUT={} expiry={}; CE={}, PE={}; subscribed={}",
-                                        instrumentKey,
-                                        nseInstrumentService.formatExpiry(sel.expiry()),
-                                        sel.ceCount(), sel.peCount(), sel.keys().size());
                             }
                         }
                     } else {
@@ -944,20 +909,14 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
     public void logResolvedLtp(String instrumentKey, double ltp, String source) {
         NseInstrument info = instrumentCache.computeIfAbsent(instrumentKey,
                 k -> mongoTemplate.findById(k, NseInstrument.class));
-        String label = instrumentKey;
         if (info != null) {
             String type = info.getInstrumentType();
-            if (type != null && type.toUpperCase().contains("FUT")) {
-                label = "NIFTY FUT";
-            } else if ("CE".equalsIgnoreCase(type) || "PE".equalsIgnoreCase(type)) {
-                Integer sp = info.getStrikePrice();
-                String strike = sp != null ? String.valueOf(sp) : "";
-                label = String.format("NIFTY %s strike=%s", type.toUpperCase(), strike);
-            } else if (info.getTradingSymbol() != null) {
-                label = info.getTradingSymbol();
+            if ("CE".equalsIgnoreCase(type) || "PE".equalsIgnoreCase(type)) {
+                log.info("OPT LTP key={} ltp={}", instrumentKey, ltp);
+                return;
             }
         }
-        log.info("LTP [{}] {}={}", label, source, ltp);
+        log.info("LTP [{}] {}={}", instrumentKey, source, ltp);
     }
 
     private void onMarketClose() {
@@ -983,7 +942,7 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
             logLtp(t.instrumentKey(), t.ltp(), t.ts().toEpochMilli());
             optRows++;
         }
-        log.info("MARKET CLOSED — last snapshot FUT={}, OPT rows={}", futPrice, optRows);
+        log.info("FLOW 8/8: MARKET CLOSED — last snapshot futLtp={} optRows={}", futPrice, optRows);
         lastTick.clear();
         optionBuffers.clear();
         connected.set(false);

--- a/apps/api/src/main/java/com/trader/backend/service/NseInstrumentService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/NseInstrumentService.java
@@ -685,7 +685,7 @@ public String selectionSignature(SelectionData sel) {
 public String formatExpiry(long expiry) {
     return Instant.ofEpochMilli(expiry).atZone(IST).toLocalDate().toString();
 }
-public void saveNiftyFuturesToMongo() {
+public long saveNiftyFuturesToMongo() {
     log.info("📂 Extracting NIFTY FUTURE records from NSE.json...");
     ensureNseJsonLoaded(false);
     List<NseInstrument> all = new ArrayList<>(nseCache);
@@ -723,6 +723,7 @@ public void saveNiftyFuturesToMongo() {
     } else {
         log.warn("⚠️ No matching NIFTY FUT records found.");
     }
+    return niftyFutures.size();
 }
 
 // helper: choose nearest non-expired NIFTY FUT using IST 3:30 PM cutoff
@@ -987,9 +988,8 @@ public void refreshNiftyOptionsByNearestExpiryFromJson() {
         long now = System.currentTimeMillis();
         Query expired = new Query(Criteria.where("expiry").lt(now));
 
-        long del1 = mongoTemplate.remove(expired, "nse_instruments").getDeletedCount();
-        long del2 = mongoTemplate.remove(expired, "filtered_nifty_premiums").getDeletedCount();
-        log.info("🧹 Purged expired: nse_instruments={}, filtered_nifty_premiums={}", del1, del2);
+        mongoTemplate.remove(expired, "nse_instruments");
+        mongoTemplate.remove(expired, "filtered_nifty_premiums");
     }
 
     @Scheduled(cron = "0 0 8 * * *", zone = "Asia/Kolkata")

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -22,7 +22,6 @@ import reactor.core.publisher.Sinks;
 import org.springframework.web.server.ResponseStatusException;
 import java.util.Base64;
 
-import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -53,13 +52,13 @@ public class UpstoxAuthService {
     private final ApiClient apiClient;
     private final LiveFeedService liveFeed;
 
-    @Value("${upstox.apiKey:}")
+    @Value("${UPSTOX_API_KEY:}")
     private String apiKey;
 
-    @Value("${upstox.apiSecret:}")
+    @Value("${UPSTOX_API_SECRET:}")
     private String apiSecret;
 
-    @Value("${upstox.webhookUri:}")
+    @Value("${UPSTOX_WEBHOOK_URI:}")
     private String webhookUri;
 
     private final AtomicReference<String> accessToken = new AtomicReference<>();
@@ -81,9 +80,8 @@ public class UpstoxAuthService {
      * Log a friendly message at boot so Railway users know the backend is
      * waiting for a login.  This method never fails.
      */
-    @PostConstruct
-    void init() {
-        log.info("No Upstox token yet — waiting for OAuth login (GET /auth/url).");
+    public void init() {
+        log.info("No Upstox token yet — waiting for OAuth login (GET /auth/url)");
         authEvents.tryEmitNext(AuthEvent.WAITING);
         state.set(State.WAIT_AUTH);
     }
@@ -146,9 +144,10 @@ public class UpstoxAuthService {
                     saveTokenBundle(at, refreshToken.get(), exp);
                     authEvents.tryEmitNext(AuthEvent.READY);
                     state.set(State.AUTH_READY);
-                    String scope = (String) tok.get("scope");
-                    log.info("[auth] token acquired exp={} scope={}",
-                            exp > 0 ? Instant.ofEpochSecond(exp) : null, scope);
+                    long nowSec = System.currentTimeMillis() / 1000;
+                    long remaining = exp - nowSec;
+                    log.info("AUTH READY: access_token saved (expires {}) remaining={}",
+                            exp > 0 ? Instant.ofEpochSecond(exp) : null, remaining);
                 })
                 .then();
     }
@@ -221,14 +220,15 @@ public class UpstoxAuthService {
                     expiresAt.set(exp);
                     apiClient.addDefaultHeader("Authorization", "Bearer " + at);
                     saveTokenBundle(at, refreshToken.get(), exp);
-                    String scope = (String) tok.get("scope");
-                    log.info("[auth] token acquired exp={} scope={}", Instant.ofEpochSecond(exp), scope);
                     authEvents.tryEmitNext(AuthEvent.READY);
                     state.set(State.AUTH_READY);
+                    long nowSec = System.currentTimeMillis() / 1000;
+                    long remaining = exp - nowSec;
+                    log.info("AUTH READY: access_token saved (expires {}) remaining={}", Instant.ofEpochSecond(exp), remaining);
                     return true;
                 })
                 .onErrorResume(e -> {
-                    log.warn("Refresh call failed", e);
+                    log.warn("AUTH EXPIRED: refresh failed — waiting for new login", e);
                     authEvents.tryEmitNext(AuthEvent.EXPIRED);
                     return Mono.just(false);
                 });


### PR DESCRIPTION
## Summary
- add startup config with env validation and boot logging
- orchestrate auth, instrument load, and live feed with detailed flow logs
- expose SSE endpoint and tighten CORS rules

## Testing
- `./mvnw -B -s .mvn/settings.xml -DskipTests package` *(failed: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b801e9f2a4832fa6972ecb5d476b72