### PR TITLE
Bootstrap NSE data on startup

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/StartupConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/StartupConfig.java
@@ -1,21 +1,13 @@
 package com.trader.backend.config;
 
-import com.trader.backend.service.UpstoxAuthService;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class StartupConfig {
-
-    private final UpstoxAuthService auth;
-
-    @Value("${UPSTOX_WEBHOOK_URI:}")
-    private String webhookUri;
 
     @Value("${SPRING_DATA_MONGODB_URI:}")
     private String mongoUri;
@@ -41,18 +33,13 @@ public class StartupConfig {
     @PostConstruct
     public void boot() {
         String mongoPresence = (mongoUri != null && !mongoUri.isBlank()) ? "present" : "absent";
-        log.info("BOOT Config: webhookUri={} mongodb.uri={} influx.org={} bucket={} cors.origins={} mock={}",
-                webhookUri,
+        log.info("BOOT Config: mongodb.uri={} influx.org={} bucket={} cors.origins={} mock={}",
                 mongoPresence,
                 influxOrg,
                 influxBucket,
                 corsOrigins,
                 mock);
 
-        if (System.getenv("UPSTOX_API_KEY") == null || System.getenv("UPSTOX_API_SECRET") == null || webhookUri == null || webhookUri.isBlank()) {
-            log.error("Missing Upstox credentials");
-            System.exit(0);
-        }
         if (mongoUri == null || mongoUri.isBlank()) {
             log.error("Missing MongoDB URI");
             System.exit(0);
@@ -64,6 +51,5 @@ public class StartupConfig {
         if (!influxOk) {
             log.warn("Influx disabled: writing skipped");
         }
-        auth.init();
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/service/NseDataInitializer.java
+++ b/apps/api/src/main/java/com/trader/backend/service/NseDataInitializer.java
@@ -1,0 +1,58 @@
+package com.trader.backend.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trader.backend.entity.NseInstrument;
+import jakarta.annotation.PostConstruct;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NseDataInitializer {
+
+    private final NSEDownloaderService downloader;
+    private final MongoTemplate mongoTemplate;
+    private final ObjectMapper mapper;
+
+    @PostConstruct
+    public void init() {
+        try {
+            downloader.downloadAndExtract();
+            InputStream is = getClass().getClassLoader().getResourceAsStream("data/NSE.json");
+            if (is == null) {
+                log.error("NSE.json not found after download");
+                return;
+            }
+            List<NseInstrument> all = Arrays.asList(mapper.readValue(is, NseInstrument[].class));
+
+            List<NseInstrument> futures = all.stream()
+                    .filter(i -> "NSE_INDEX|Nifty 50".equals(i.getUnderlyingKey()))
+                    .filter(i -> i.getInstrumentType() != null && i.getInstrumentType().startsWith("FUT"))
+                    .collect(Collectors.toList());
+            mongoTemplate.dropCollection("nifty_futures");
+            if (!futures.isEmpty()) {
+                mongoTemplate.insert(futures, "nifty_futures");
+            }
+
+            List<NseInstrument> premium = all.stream()
+                    .filter(i -> "NSE_INDEX|Nifty 50".equals(i.getUnderlyingKey()))
+                    .filter(i -> "CE".equals(i.getInstrumentType()) || "PE".equals(i.getInstrumentType()))
+                    .collect(Collectors.toList());
+            mongoTemplate.dropCollection("premium");
+            if (!premium.isEmpty()) {
+                mongoTemplate.insert(premium, "premium");
+            }
+
+            log.info("NSE bootstrap: futures={} premium={}", futures.size(), premium.size());
+        } catch (Exception e) {
+            log.error("NSE bootstrap failed", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- download and parse NSE instrument JSON on startup
- persist NIFTY futures and CE/PE premiums to Mongo collections
- drop Upstox credentials check from startup config

## Testing
- `./mvnw -q -f apps/api/pom.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b80def0054832f9d769e792ac522cb