### PR TITLE
Add pickCurrentExpiry helper and integrate with NseInstrumentService

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/service/ExpirySelectorService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/ExpirySelectorService.java
@@ -32,8 +32,8 @@ public class ExpirySelectorService {
         this.mongoTemplate = null;
     }
 
-    public void ensureCurrentWeeklyExpiry() {
-        selectCurrentOptionExpiry(ZonedDateTime.now(IST));
+    public String ensureCurrentWeeklyExpiry() {
+        return selectCurrentOptionExpiry(ZonedDateTime.now(IST)).toString();
     }
 
     /**
@@ -68,12 +68,12 @@ public class ExpirySelectorService {
         return next;
     }
 
-    public LocalDate pickCurrentExpiry(ZonedDateTime nowIst) {
-        return selectCurrentOptionExpiry(nowIst);
-    }
-
-    public LocalDate pickCurrentExpiry(Instant nowUtc) {
-        return selectCurrentOptionExpiry(ZonedDateTime.ofInstant(nowUtc, IST));
+    /**
+     * Returns the current weekly expiry string given an Instant.
+     */
+    public String pickCurrentExpiry(Instant now) {
+        // Delegate to existing logic for determining the current weekly expiry
+        return ensureCurrentWeeklyExpiry();
     }
 
     /**

--- a/apps/api/src/main/java/com/trader/backend/service/NseInstrumentService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/NseInstrumentService.java
@@ -177,7 +177,8 @@ public class NseInstrumentService {
      * Triggers refreshFromNseJson() once if empty.
      */
     public synchronized boolean ensureOptionsLoaded(ZonedDateTime nowIst) {
-        LocalDate current = expirySelectorService.selectCurrentOptionExpiry(nowIst);
+        String expiry = expirySelectorService.pickCurrentExpiry(Instant.now());
+        LocalDate current = LocalDate.parse(expiry);
         long expMs = current.atStartOfDay(nowIst.getZone()).toInstant().toEpochMilli();
         Query q = new Query(new Criteria().andOperator(
                 Criteria.where("instrumentType").in("CE", "PE"),


### PR DESCRIPTION
## Summary
- expose weekly expiry string via new `ExpirySelectorService.pickCurrentExpiry` helper
- use the helper in `NseInstrumentService` when loading option data

## Testing
- `./mvnw -q -f apps/api/pom.xml test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8519a3c60832f9b994a54e0c4fc3a