### PR TITLE
Add InfluxDB client config and NSE data fallback

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/InfluxConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/InfluxConfig.java
@@ -2,44 +2,24 @@ package com.trader.backend.config;
 
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
-import com.influxdb.client.WriteApiBlocking;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class InfluxConfig {
 
-    @Value("${INFLUX_URL:}")
+    @Value("${influx.url}")
     private String url;
 
-    @Value("${INFLUX_TOKEN:}")
+    @Value("${influx.token}")
     private String token;
 
-    @Value("${INFLUX_ORG:}")
+    @Value("${influx.org}")
     private String org;
 
-    @Value("${INFLUX_BUCKET:}")
-    private String bucket;
-
-    /**
-     * Create a singleton InfluxDBClient that knows your URL, token, org & bucket.
-     */
     @Bean
-    @ConditionalOnProperty(name = "INFLUX_URL")
     public InfluxDBClient influxDBClient() {
-        // note: token must be passed as char[] for security
-        return InfluxDBClientFactory.create(url, token.toCharArray(), org, bucket);
-    }
-
-    /**
-     * Expose the WriteApiBlocking so you can inject it into your service.
-     */
-    @Bean
-    @ConditionalOnBean(InfluxDBClient.class)
-    public WriteApiBlocking writeApi(InfluxDBClient influxDBClient) {
-        return influxDBClient.getWriteApiBlocking();
+        return InfluxDBClientFactory.create(url, token.toCharArray(), org);
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/config/StartupConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/StartupConfig.java
@@ -12,16 +12,16 @@ public class StartupConfig {
     @Value("${SPRING_DATA_MONGODB_URI:}")
     private String mongoUri;
 
-    @Value("${INFLUX_URL:}")
+    @Value("${influx.url:}")
     private String influxUrl;
 
-    @Value("${INFLUX_TOKEN:}")
+    @Value("${influx.token:}")
     private String influxToken;
 
-    @Value("${INFLUX_ORG:}")
+    @Value("${influx.org:}")
     private String influxOrg;
 
-    @Value("${INFLUX_BUCKET:}")
+    @Value("${influx.bucket:}")
     private String influxBucket;
 
     @Value("${APP_CORS_ALLOWED_ORIGINS:}")

--- a/apps/api/src/main/java/com/trader/backend/service/NSEBootstrapService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/NSEBootstrapService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import javax.annotation.PostConstruct;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -50,7 +52,18 @@ public class NSEBootstrapService {
 
     public synchronized int refresh() {
         try {
-            String json = webClient.get().uri(nseUrl).retrieve().bodyToMono(String.class).block();
+            String json;
+            if (nseUrl == null || nseUrl.isBlank()) {
+                try (InputStream is = getClass().getResourceAsStream("/nse_fno_data.json")) {
+                    if (is == null) {
+                        log.error("Failed to load nse_fno_data.json from classpath");
+                        return 0;
+                    }
+                    json = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                }
+            } else {
+                json = webClient.get().uri(nseUrl).retrieve().bodyToMono(String.class).block();
+            }
             JsonNode arr = mapper.readTree(json);
             List<Instrument> list = new ArrayList<>();
             for (JsonNode n : arr) {

--- a/apps/api/src/main/java/com/trader/backend/service/TickStore.java
+++ b/apps/api/src/main/java/com/trader/backend/service/TickStore.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class TickStore {
     private final InfluxTickService influxTickService;
 
-    @Value("${INFLUX_URL:}")
+    @Value("${influx.url:}")
     private String influxUrl;
 
     private final Map<String, Tick> latest = new ConcurrentHashMap<>();

--- a/apps/api/src/main/resources/application.properties
+++ b/apps/api/src/main/resources/application.properties
@@ -9,6 +9,10 @@ spring.main.banner-mode=console
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
 
+# NSE FNO data fallback
+NSE_FNO_JSON_URL=https://example.com/nse_fno_data.json
+NSE_CACHE_TTL_MIN=1440
+
 # Frontend configuration
 frontend.dashboard-url=${FRONTEND_DASHBOARD_URL:https://combinedfrontendbackend.vercel.app/dashboard}
 # MongoDB configuration
@@ -29,18 +33,12 @@ spring.redis.port=6379
 #logging.level.com.trader.backend.service.UpstoxAuthService=DEBUG
 #logging.level.com.trader.backend.service.LiveFeedService=DEBUG
 #logging.level.com.trader.backend.scheduler.NseJsonDownloader=DEBUG
-# your Cloud-2 URL (include the ?1? if that?s what your UI shows)
-influx.url=https://us-east-1-1.aws.cloud2.influxdata.com
 
-# the token you just generated in the UI (must have write scope on your bucket)
-influx.token=wwwL6sNhLj8_C4k-n5nxndx2hTTwf_kZMFkqbvkBjohPp5_F4SKE6mlSEC-bco3sUreA70PExOhby-Pmfl_0yQ==
-
-# your organization name or ID (e.g. ?Johntradecorp?)
-influx.org=Johntradecorp
-
-# the name of the bucket you created (e.g. ?Ticks?)
-influx.bucket=Ticks
-
+# InfluxDB settings
+influx.url=http://localhost:8086
+influx.token=my-secret-token
+influx.org=my-org
+influx.bucket=my-bucket
 
 #logging.level.com.trader.backend.service.StreamController=DEBUG
 #logging.level.com.trader.backend.service.NseInstrumentService=DEBUG

--- a/apps/api/src/main/resources/nse_fno_data.json
+++ b/apps/api/src/main/resources/nse_fno_data.json
@@ -1,0 +1,17 @@
+[
+  {
+    "instrument_key": "NSE_TEST_FUT",
+    "name": "TEST FUT",
+    "instrument_type": "FUT",
+    "expiry": 0,
+    "segment": "NSE"
+  },
+  {
+    "instrument_key": "NSE_TEST_OPT",
+    "name": "TEST OPT",
+    "instrument_type": "OPTCE",
+    "expiry": 0,
+    "strike_price": 0,
+    "segment": "NSE"
+  }
+]


### PR DESCRIPTION
## Summary
- add classpath fallback for NSE instrument bootstrap
- configure InfluxDB client bean with influx.* properties
- bundle sample FNO data and application defaults

## Testing
- `cd apps/api && ./mvnw -q test` *(fails: Non-resolvable parent POM – network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b882467534832f82770c00365913b9