### PR TITLE
Increase WebClient buffer size to handle large NSE data

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/service/NSEBootstrapService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/NSEBootstrapService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 
 import javax.annotation.PostConstruct;
 import java.io.InputStream;
@@ -35,7 +36,11 @@ public class NSEBootstrapService {
 
     private volatile long lastLoaded = 0L;
 
-    private final WebClient webClient = WebClient.builder().build();
+    private final WebClient webClient = WebClient.builder()
+            .exchangeStrategies(ExchangeStrategies.builder()
+                    .codecs(cfg -> cfg.defaultCodecs().maxInMemorySize(16 * 1024 * 1024))
+                    .build())
+            .build();
 
     @PostConstruct
     public void init() {


### PR DESCRIPTION
## Summary
- expand WebClient in-memory buffer limit so NSE bootstrap can download large instrument files without failing

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b88a516db0832f91765cff071d683e