### PR TITLE
Read MongoDB URI from properties

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/StartupConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/StartupConfig.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class StartupConfig {
 
-    @Value("${SPRING_DATA_MONGODB_URI:}")
+    @Value("${spring.data.mongodb.uri:}")
     private String mongoUri;
 
     @Value("${influx.url:}")


### PR DESCRIPTION
## Summary
- read MongoDB URI from `spring.data.mongodb.uri` so it can be configured via application properties

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68b88c90817c832f9df860adfc8e32f7