### PR TITLE
Handle missing Upstox credentials gracefully

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/controller/AuthController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/AuthController.java
@@ -4,8 +4,10 @@ import com.trader.backend.service.UpstoxAuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -26,8 +28,12 @@ public class AuthController {
     /** Return the OAuth dialog URL for the frontend. */
     @GetMapping("/url")
     public Map<String, String> loginUrl() {
+        String url = auth.buildAuthUrl();
+        if (url == null) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Upstox credentials not configured");
+        }
         Map<String, String> body = new LinkedHashMap<>();
-        body.put("url", auth.buildAuthUrl());
+        body.put("url", url);
         return body;
     }
 

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -379,7 +379,8 @@ public class UpstoxAuthService {
     /** Build the Upstox OAuth dialog URL for the frontend. */
     public String buildAuthUrl() {
         if (apiKey.isBlank() || webhookUri.isBlank()) {
-            throw new IllegalStateException("Upstox credentials not configured");
+            log.warn("Upstox credentials not configured");
+            return null;
         }
 
         return UriComponentsBuilder


### PR DESCRIPTION
## Summary
- Avoid throwing an exception when Upstox credentials are absent; log and return null instead
- Return HTTP 503 from `/auth/url` when credentials are missing

## Testing
- `./mvnw -q -o test` *(fails: Non-resolvable parent POM for com.trader:backend:0.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b88e91d094832f8e2c3b59a3cb7bff