### PR TITLE
Allow configurable CORS and trim logs

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package com.trader.backend.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,10 +8,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
+    @Value("${APP_CORS_ALLOWED_ORIGINS:*}")
+    private String allowedOrigins;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("https://combinedfrontendbackend.vercel.app")
+                .allowedOriginPatterns(allowedOrigins.split(","))
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/apps/api/src/main/resources/application.properties
+++ b/apps/api/src/main/resources/application.properties
@@ -2,7 +2,8 @@ spring.application.name=backend
 server.port=${PORT:8080}
 server.address=0.0.0.0
 spring.main.web-application-type=servlet
-logging.level.root=INFO
+logging.level.root=WARN
+logging.level.com.trader.backend=INFO
 spring.main.banner-mode=console
 
 # Expose only the health endpoint for Railway
@@ -59,7 +60,6 @@ logging.level.reactor.netty=WARN
 logging.level.io.netty=WARN
 logging.level.okhttp3=WARN
 logging.level.com.upstox=WARN
-logging.level.root=INFO
 
 
 # --- UI CORS ---


### PR DESCRIPTION
## Summary
- Make CORS origin configurable and default to allow all
- Reduce default logging to warn while keeping backend info logs

## Testing
- `./mvnw -q test` *(fails: Could not resolve parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b89225601c832f8e42458643e7e70d