### PR TITLE
feat: expose backend CORS origins as config property

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
-    @Value("${APP_CORS_ALLOWED_ORIGINS:*}")
+    @Value("${cors.allowedOrigins:https://frontendfortheautobot.vercel.app,http://localhost:4200}")
     private String allowedOrigins;
 
     @Override


### PR DESCRIPTION
## Summary
- make backend CORS origins configurable with `cors.allowedOrigins`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b89809d9fc832fb8cfb668f8a647d3