### PR TITLE
fix: allow vercel frontend domain via CORS

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
-    @Value("${cors.allowedOrigins:https://frontendfortheautobot.vercel.app,http://localhost:4200}")
+    @Value("${cors.allowedOrigins:https://combinedfrontendbackend.vercel.app,https://frontendfortheautobot.vercel.app,http://localhost:4200}")
     private String allowedOrigins;
 
     @Override

--- a/apps/api/src/main/resources/application.properties
+++ b/apps/api/src/main/resources/application.properties
@@ -64,3 +64,5 @@ logging.level.com.upstox=WARN
 
 # --- UI CORS ---
 
+cors.allowedOrigins=https://combinedfrontendbackend.vercel.app,https://frontendfortheautobot.vercel.app,http://localhost:4200
+


### PR DESCRIPTION
## Summary
- include `combinedfrontendbackend.vercel.app` as default allowed CORS origin for backend
- expose new CORS origin property in application config

## Testing
- `./mvnw -f apps/api/pom.xml test` *(fails: Could not resolve spring-boot-starter-parent from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68b89a43e738832f8b14d3e018f6814c