### PR TITLE
Fix CORS settings for production frontend

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -1,27 +1,49 @@
 package com.trader.backend.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
+import java.util.Arrays;
+import java.util.List;
+
+@ComponentScan
 @Configuration
-public class CorsConfig implements WebMvcConfigurer {
+@EnableWebMvc
+public class CorsConfig {
 
-    @Value("${cors.allowedOrigins:https://combinedfrontendbackend.vercel.app}")
+    @Value("${cors.allowedOrigins:https://frontendfortheautobot.vercel.app,http://localhost:4200,https://combinedfrontendbackend.vercel.app}")
     private String allowedOrigins;
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                // Use allowedOrigins instead of allowedOriginPatterns so Spring sets
-        // the Access-Control-Allow-Origin header on responses. The previous
-        // configuration relied on pattern matching which can omit the header and
-        // trigger CORS errors in browsers.
-                .allowedOrigins(allowedOrigins.split(","))
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true);
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(false);
+        config.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
+        config.setAllowedHeaders(List.of("Content-Type"));
+        config.setAllowedMethods(List.of("GET"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        List<String> paths = List.of(
+                "/auth/**",
+                "/md/selection",
+                "/md/candles",
+                "/md/stream",
+                "/md/last-ltp",
+                "/md/ltp",
+                "/md/sector-trades",
+                "/ops/live-status",
+                "/ops/influx-sanity",
+                "/ops/market-clock"
+        );
+        paths.forEach(p -> source.registerCorsConfiguration(p, config));
+
+        return new CorsFilter(source);
     }
 }
 


### PR DESCRIPTION
## Summary
- configure Spring CorsFilter with explicit allowed origins for production frontend and other paths

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a2c90830832f8ce7a3ce331b62ca