### PR TITLE
Fix Upstox credential property mapping for login

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -52,13 +52,13 @@ public class UpstoxAuthService {
     private final ApiClient apiClient;
     private final LiveFeedService liveFeed;
 
-    @Value("${UPSTOX_API_KEY:}")
+    @Value("${upstox.apiKey}")
     private String apiKey;
 
-    @Value("${UPSTOX_API_SECRET:}")
+    @Value("${upstox.apiSecret}")
     private String apiSecret;
 
-    @Value("${UPSTOX_WEBHOOK_URI:}")
+    @Value("${upstox.webhookUri}")
     private String webhookUri;
 
     private final AtomicReference<String> accessToken = new AtomicReference<>();


### PR DESCRIPTION
## Summary
- read Upstox API credentials strictly from `upstox.*` properties without env fallbacks

## Testing
- `./mvnw -q -f apps/api/pom.xml test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b91c1b2784832fb6de74df7e001820