### PR TITLE
Use Upstox v2 for auth and v3 for market data

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/UpstoxFeedTester.java
+++ b/apps/api/src/main/java/com/trader/backend/UpstoxFeedTester.java
@@ -11,6 +11,8 @@ import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClien
 import org.springframework.core.ParameterizedTypeReference;
 import reactor.core.publisher.Mono;
 
+import static com.trader.backend.config.UpstoxApiEndpoints.*;
+
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
@@ -31,7 +33,7 @@ public class UpstoxFeedTester {
     public static void main(String[] args) throws InterruptedException {
         ObjectMapper mapper = new ObjectMapper();
         WebClient authClient = WebClient.builder()
-                .baseUrl("https://api.upstox.com/v2")
+                .baseUrl(API_V2_BASE_URL)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .build();
 
@@ -61,13 +63,13 @@ public class UpstoxFeedTester {
                 .build();
 
         String wsUrl = feedClient.get()
-                .uri("https://api.upstox.com/v3/feed/market-data-feed/authorize")
+                .uri(API_V3_BASE_URL + "/feed/market-data-feed/authorize")
                 .exchangeToMono(resp -> {
                     if (resp.statusCode().is3xxRedirection()) {
                         return Mono.just(resp.headers().asHttpHeaders().getLocation().toString());
                     }
                     return resp.bodyToMono(JsonNode.class)
-                            .map(j -> "wss://api.upstox.com/v3/feed/market-data-feed?authorization="
+                            .map(j -> FEED_WS_V3_BASE_URL + "?authorization="
                                     + j.at("/data/feed_token").asText());
                 })
                 .block(Duration.ofSeconds(10));

--- a/apps/api/src/main/java/com/trader/backend/config/UpstoxApiEndpoints.java
+++ b/apps/api/src/main/java/com/trader/backend/config/UpstoxApiEndpoints.java
@@ -1,0 +1,19 @@
+package com.trader.backend.config;
+
+/**
+ * Central place for Upstox API base URLs. Upstox requires that
+ * OAuth and most REST endpoints use the v2 base URL while
+ * market data feeds are served from v3 endpoints.
+ */
+public final class UpstoxApiEndpoints {
+    private UpstoxApiEndpoints() {}
+
+    /** Base URL for Upstox v2 REST APIs including OAuth. */
+    public static final String API_V2_BASE_URL = "https://api.upstox.com/v2";
+
+    /** Base URL for Upstox v3 APIs such as the market data feed. */
+    public static final String API_V3_BASE_URL = "https://api.upstox.com/v3";
+
+    /** WebSocket base URL for the v3 market data feed. */
+    public static final String FEED_WS_V3_BASE_URL = "wss://api.upstox.com/v3/feed/market-data-feed";
+}

--- a/apps/api/src/main/java/com/trader/backend/config/UpstoxClientConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/UpstoxClientConfig.java
@@ -2,9 +2,9 @@ package com.trader.backend.config;
 
 import com.upstox.ApiClient;
 import com.upstox.Configuration;
-import com.upstox.auth.OAuth;
 import org.springframework.context.annotation.Bean;
 
+import static com.trader.backend.config.UpstoxApiEndpoints.API_V2_BASE_URL;
 
 @org.springframework.context.annotation.Configuration
 public class UpstoxClientConfig {
@@ -13,7 +13,7 @@ public class UpstoxClientConfig {
     public ApiClient upstoxApiClient() {
         // Just create once; we’ll inject the token later
         ApiClient client = Configuration.getDefaultApiClient();
-        client.setBasePath("https://api.upstox.com/v2");
+        client.setBasePath(API_V2_BASE_URL);
         return client;
     }
 }

--- a/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.beans.factory.annotation.Value;
+import static com.trader.backend.config.UpstoxApiEndpoints.*;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -316,13 +317,13 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
                 .build();
 
         return client.get()
-                .uri("https://api.upstox.com/v3/feed/market-data-feed/authorize")
+                .uri(API_V3_BASE_URL + "/feed/market-data-feed/authorize")
                 .exchangeToMono(resp -> {
                     if (resp.statusCode().is3xxRedirection()) {
                         return Mono.just(resp.headers().asHttpHeaders().getLocation().toString());
                     }
                     return resp.bodyToMono(JsonNode.class)
-                            .map(j -> "wss://api.upstox.com/v3/feed/market-data-feed?authorization="
+                            .map(j -> FEED_WS_V3_BASE_URL + "?authorization="
                                     + j.at("/data/feed_token").asText());
                 })
                 .doOnNext(url -> log.info("▶︎ connecting to WS at {}", url));

--- a/apps/api/src/main/java/com/trader/backend/service/MarketDataService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/MarketDataService.java
@@ -12,6 +12,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
+import static com.trader.backend.config.UpstoxApiEndpoints.API_V3_BASE_URL;
+
 import java.net.URI;
 
 @Service
@@ -30,7 +32,7 @@ public class MarketDataService {
                                  String to,
                                  @Nullable String from) {
 
-        WebClient wc = buildClient("https://api.upstox.com");
+        WebClient wc = buildClient(API_V3_BASE_URL);
 
         URI uri = buildHistUri(key, unit, interval, to, from);
 
@@ -54,7 +56,7 @@ public class MarketDataService {
                              String to,
                              @Nullable String from) {
         UriComponentsBuilder b = UriComponentsBuilder
-                .fromPath("/v3/historical-candle/{key}")
+                .fromPath("/historical-candle/{key}")
                 .queryParam("to", to);
         if (from != null && !from.isBlank()) {
             b.queryParam("from", from);

--- a/apps/api/src/main/java/com/trader/backend/service/NseInstrumentService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/NseInstrumentService.java
@@ -22,6 +22,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.http.HttpHeaders;
 import reactor.core.publisher.Mono;
 import org.springframework.beans.factory.annotation.Value;
+import static com.trader.backend.config.UpstoxApiEndpoints.API_V2_BASE_URL;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
@@ -805,7 +806,7 @@ public Mono<Double> getNearestExpiryNiftyFutureLtp() {
     log.info("📌 Selected NIFTY FUT key for LTP: " + instrumentKey);
 
     // 3. Call Upstox LTP API
-    String url = "https://api.upstox.com/v2/market-quote/ltp?instrument_key=" + instrumentKey;
+    String url = API_V2_BASE_URL + "/market-quote/ltp?instrument_key=" + instrumentKey;
 
     return webClient.get()
             .uri(url)

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -16,6 +16,7 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
+import static com.trader.backend.config.UpstoxApiEndpoints.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -43,7 +44,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class UpstoxAuthService {
 
     private final WebClient webClient = WebClient.builder()
-            .baseUrl("https://api.upstox.com/v2")
+            .baseUrl(API_V2_BASE_URL)
             .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
             .filter(logRequest())
             .filter(logResponse())
@@ -384,7 +385,7 @@ public class UpstoxAuthService {
         }
 
         return UriComponentsBuilder
-                .fromUriString("https://api.upstox.com/v2/login/authorization/dialog")
+                .fromUriString(API_V2_BASE_URL + "/login/authorization/dialog")
                 .queryParam("response_type", "code")
                 .queryParam("client_id", apiKey)
                 .queryParam("redirect_uri", webhookUri)


### PR DESCRIPTION
## Summary
- Centralize Upstox API base URLs and WebSocket endpoint constants
- Route authentication and account calls through v2 APIs
- Fetch market data via v3 endpoints and WebSocket feed

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b93f1d10a8832f9573f50d2f5f6307