### PR TITLE
fix: remove hardcoded Maven proxy settings

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,6 +1,6 @@
--Djava.net.useSystemProxies=true
--Dhttp.proxyHost=proxy
--Dhttp.proxyPort=8080
--Dhttps.proxyHost=proxy
--Dhttps.proxyPort=8080
+-Djava.net.useSystemProxies=false
+-Dhttp.proxyHost=
+-Dhttp.proxyPort=0
+-Dhttps.proxyHost=
+-Dhttps.proxyPort=0
 -Djava.net.preferIPv4Stack=true


### PR DESCRIPTION
## Summary
- remove proxy host and port entries from Maven JVM config so builds don't route through a nonexistent proxy

## Testing
- `./mvnw -B -s .mvn/settings.xml -f apps/api/pom.xml test` *(fails: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c9db1ef4832fabfa33c32a8ac209