### PR TITLE
fix: remove hardcoded Maven proxy settings

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,6 +1,6 @@
--Djava.net.useSystemProxies=true
--Dhttp.proxyHost=proxy
--Dhttp.proxyPort=8080
--Dhttps.proxyHost=proxy
--Dhttps.proxyPort=8080
+-Djava.net.useSystemProxies=false
+-Dhttp.proxyHost=
+-Dhttp.proxyPort=0
+-Dhttps.proxyHost=
+-Dhttps.proxyPort=0
 -Djava.net.preferIPv4Stack=true

--- a/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/apps/api/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -23,10 +23,10 @@ public class CorsConfig {
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(false);
+        config.setAllowCredentials(true);
         config.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
-        config.setAllowedHeaders(List.of("Content-Type"));
-        config.setAllowedMethods(List.of("GET"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         List<String> paths = List.of(


### PR DESCRIPTION
## Summary
- remove proxy host and port entries from Maven JVM config so builds don't route through a nonexistent proxy
- expand backend CORS configuration to allow common methods, headers, and credentials

## Testing
- `./mvnw -B -s .mvn/settings.xml -f apps/api/pom.xml test` *(fails: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c9db1ef4832fabfa33c32a8ac209