### PR TITLE
Encode Upstox OAuth URL

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -391,7 +391,9 @@ public class UpstoxAuthService {
                 .queryParam("redirect_uri", webhookUri)
                 .queryParam("state", "botInit")
                 .queryParam("scope", "profile marketdata")
-                .build().toUriString();
+                .build()
+                .encode()
+                .toUriString();
     }
 
     private static ExchangeFilterFunction logRequest() {


### PR DESCRIPTION
## Summary
- ensure Upstox OAuth dialog URL is properly URL-encoded

## Testing
- `./mvnw -B -s .mvn/settings.xml -f apps/api/pom.xml clean package` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d0b15cf0832f9c6483e386d15cf3