### PR TITLE
Redirect login button to Upstox auth URL

### DIFF
--- a/apps/web/src/app/pages/login/login.component.ts
+++ b/apps/web/src/app/pages/login/login.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-login',
@@ -7,11 +6,12 @@ import { AuthService } from '../../services/auth.service';
   styleUrls: ['./login.component.css']
 })
 export class LoginComponent {
-  constructor(private auth: AuthService) {}
+  /** Direct Upstox authorization URL */
+  private readonly upstoxLoginUrl =
+    'https://api.upstox.com/v2/login/authorization/dialog?response_type=code&client_id=97fde129-556b-4a84-9083-9fea5eb53fb0&redirect_uri=https%3A%2F%2Fcombinedfrontendbackend-production.up.railway.app%2Fauth&state=botInit&scope=profile%20marketdata';
 
+  /** Redirect the user to the Upstox login page */
   login() {
-    this.auth.getLoginUrl().subscribe({
-      next: url => (window.location.href = url)
-    });
+    window.location.href = this.upstoxLoginUrl;
   }
 }


### PR DESCRIPTION
## Summary
- Redirect login button directly to Upstox authorization endpoint
- Simplify login component by removing backend call

## Testing
- `npm test -- --watch=false` *(fails: TS18003: No inputs were found in config file '/workspace/Combinedfrontendbackend/apps/web/tsconfig.spec.json')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9d3fcf250832f8ca939dc2b12c7f9