### PR TITLE
Use backend login redirect to avoid CORS issues

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/controller/AuthController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.Map;
 import java.util.LinkedHashMap;
 
@@ -24,6 +25,16 @@ public class AuthController {
 
     @Value("${frontend.dashboard-url}")
     private String frontendDashboardUrl;
+
+    /** Redirect straight to the Upstox OAuth dialog. */
+    @GetMapping("/login")
+    public void login(HttpServletResponse response) throws IOException {
+        String url = auth.buildAuthUrl();
+        if (url == null) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Upstox credentials not configured");
+        }
+        response.sendRedirect(url);
+    }
 
     /** Return the OAuth dialog URL for the frontend. */
     @GetMapping("/url")

--- a/apps/web/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/web/src/app/pages/dashboard/dashboard.component.ts
@@ -87,7 +87,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   login() {
-    this.auth.getLoginUrl().subscribe({ next: url => (window.location.href = url) });
+    this.auth.redirectToLogin();
   }
 
   refresh() {

--- a/apps/web/src/app/pages/login/login.component.ts
+++ b/apps/web/src/app/pages/login/login.component.ts
@@ -12,8 +12,6 @@ export class LoginComponent {
 
   /** Redirect the user to the Upstox login page */
   login() {
-    this.auth.getLoginUrl().subscribe({
-      next: url => (window.location.href = url)
-    });
+    this.auth.redirectToLogin();
   }
 }

--- a/apps/web/src/app/services/auth.service.ts
+++ b/apps/web/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { map, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 export interface AuthStatus {
@@ -14,11 +14,9 @@ export class AuthService {
   private http = inject(HttpClient);
   private apiBase = environment.apiBase;
 
-  /** Ask the backend for the login URL */
-  getLoginUrl(): Observable<string> {
-    return this.http
-      .get<{ url: string }>(`${this.apiBase}/auth/url`)
-      .pipe(map(r => r.url));
+  /** Redirect the browser to the backend login endpoint. */
+  redirectToLogin() {
+    window.location.href = `${this.apiBase}/auth/login`;
   }
 
   /** Fetch the current auth status */


### PR DESCRIPTION
## Summary
- redirect frontend login actions directly to the backend `/auth/login` endpoint
- expose `/auth/login` in the Spring controller for Upstox OAuth

## Testing
- `npm run build --prefix apps/web`
- `npm test --prefix apps/web -- --watch=false --browsers=ChromeHeadless` *(fails: No inputs were found in config file)*
- `./mvnw -q -f apps/api/pom.xml test` *(fails: could not resolve Maven parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dac866ac832fa07f3c8e8272b1f4