### PR TITLE
Fix Upstox OAuth redirect for Railway deployment

### DIFF
--- a/apps/api/src/main/resources/application.properties
+++ b/apps/api/src/main/resources/application.properties
@@ -23,7 +23,7 @@ spring.data.mongodb.database=ClusterDev
 upstox.apiKey=97fde129-556b-4a84-9083-9fea5eb53fb0
 upstox.apiSecret=ofye1h1t8e
 # URL for OAuth webhook callback for Railway deployment
-upstox.webhookUri=${UPSTOX_WEBHOOK_URI:https://combinedfrontendbackend.vercel.app/auth}
+upstox.webhookUri=${UPSTOX_WEBHOOK_URI:https://combinedfrontendbackend-production.up.railway.app/auth}
 #logging.level.reactor.netty.http.client=INFO
 
 spring.redis.host=localhost   # Redis later; leave like this


### PR DESCRIPTION
## Summary
- fix Upstox OAuth callback to default to Railway URL

## Testing
- `./mvnw -q test` *(fails: Network is unreachable to repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68ba72dbdd9c832f9ac805b1ffd81d59