### PR TITLE
Redirect auth URL to Upstox login

### DIFF
--- a/apps/api/src/main/java/com/trader/backend/controller/AuthController.java
+++ b/apps/api/src/main/java/com/trader/backend/controller/AuthController.java
@@ -36,16 +36,10 @@ public class AuthController {
         response.sendRedirect(url);
     }
 
-    /** Return the OAuth dialog URL for the frontend. */
+    /** Convenience endpoint that also redirects to the OAuth dialog. */
     @GetMapping("/url")
-    public Map<String, String> loginUrl() {
-        String url = auth.buildAuthUrl();
-        if (url == null) {
-            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Upstox credentials not configured");
-        }
-        Map<String, String> body = new LinkedHashMap<>();
-        body.put("url", url);
-        return body;
+    public void loginUrl(HttpServletResponse response) throws IOException {
+        login(response);
     }
 
     @GetMapping("/redirect-url")

--- a/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/apps/api/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -82,7 +82,7 @@ public class UpstoxAuthService {
      * waiting for a login.  This method never fails.
      */
     public void init() {
-        log.info("No Upstox token yet — waiting for OAuth login (GET /auth/url)");
+        log.info("No Upstox token yet — waiting for OAuth login (GET /auth/login or /auth/url)");
         authEvents.tryEmitNext(AuthEvent.WAITING);
         state.set(State.WAIT_AUTH);
     }


### PR DESCRIPTION
## Summary
- Redirect `/auth/url` to the Upstox OAuth dialog so the endpoint opens the login page directly
- Update startup log message to mention `/auth/login` or `/auth/url`

## Testing
- `./apps/api/mvnw -q -o -Poffline-ready test` *(fails: Non-resolvable parent POM – dependencies missing in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68ba74ed1f0c832f88333049a845cca6